### PR TITLE
Fix error when projects contain UnitEnums.

### DIFF
--- a/src/Collectors/Enums.php
+++ b/src/Collectors/Enums.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ranger\Collectors;
 
+use BackedEnum;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\Enum as EnumComponent;
 use ReflectionClass;
@@ -19,12 +20,12 @@ class Enums extends Collector
     }
 
     /**
-     * @param  class-string<\BackedEnum>  $enum
+     * @param  class-string<\BackedEnum|\UnitEnum>  $enum
      */
     protected function toComponent(string $enum): EnumComponent
     {
         $cases = collect($enum::cases())
-            ->mapWithKeys(fn ($case) => [$case->name => $case->value])
+            ->mapWithKeys(fn ($case) => [$case->name => $case instanceof BackedEnum ? $case->value : null])
             ->all();
 
         $component = new EnumComponent($enum, $cases);

--- a/src/Components/Enum.php
+++ b/src/Components/Enum.php
@@ -9,7 +9,7 @@ class Enum
     use HasFilePath;
 
     /**
-     * @param  array<string, string>  $cases
+     * @param  array<string, int|string|null>  $cases
      */
     public function __construct(
         public readonly string $name,

--- a/tests/Feature/EnumsTest.php
+++ b/tests/Feature/EnumsTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Enums\NumericEnum;
 use App\Enums\Status;
+use App\Enums\UnitEnum;
 use App\Enums\UserRole;
 use Laravel\Ranger\Collectors\Enums;
 use Laravel\Ranger\Components\Enum;
@@ -12,7 +14,7 @@ beforeEach(function () {
 it('collects all enums from the application', function () {
     $enums = $this->collector->collect();
 
-    expect($enums)->toHaveCount(2);
+    expect($enums)->toHaveCount(4);
     expect($enums->pluck('name')->toArray())->toContain(Status::class, UserRole::class);
 });
 
@@ -56,6 +58,30 @@ it('captures user role enum cases correctly', function () {
         'GUEST' => 'guest',
         'EDITOR' => 'editor',
         'VIEWER' => 'viewer',
+    ]);
+});
+
+it('captures numeric enum cases correctly', function () {
+    $enums = $this->collector->collect();
+
+    $userRole = $enums->first(fn (Enum $e) => $e->name === NumericEnum::class);
+
+    expect($userRole->cases)->toHaveCount(2);
+    expect($userRole->cases)->toMatchArray([
+        'ONE' => 1,
+        'TWO' => 2,
+    ]);
+});
+
+it('captures unit enum cases correctly', function () {
+    $enums = $this->collector->collect();
+
+    $userRole = $enums->first(fn (Enum $e) => $e->name === UnitEnum::class);
+
+    expect($userRole->cases)->toHaveCount(2);
+    expect($userRole->cases)->toMatchArray([
+        'BAR' => null,
+        'FOO' => null,
     ]);
 });
 

--- a/tests/Feature/RangerTest.php
+++ b/tests/Feature/RangerTest.php
@@ -123,7 +123,7 @@ describe('enum callbacks', function () {
 
         $this->ranger->walk();
 
-        expect($enums)->toHaveCount(2);
+        expect($enums)->toHaveCount(4);
     });
 
     it('registers onEnums collection callback', function () {
@@ -136,7 +136,7 @@ describe('enum callbacks', function () {
         $this->ranger->walk();
 
         expect($receivedCollection)->toBeInstanceOf(Collection::class);
-        expect($receivedCollection)->toHaveCount(2);
+        expect($receivedCollection)->toHaveCount(4);
     });
 });
 
@@ -212,7 +212,7 @@ describe('multiple callbacks', function () {
 
         $this->ranger->walk();
 
-        expect($callCount)->toBe(4);
+        expect($callCount)->toBe(8);
     });
 
     it('supports callbacks for different types', function () {

--- a/workbench/app/Enums/NumericEnum.php
+++ b/workbench/app/Enums/NumericEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum NumericEnum: int
+{
+    case ONE = 1;
+    case TWO = 2;
+}

--- a/workbench/app/Enums/UnitEnum.php
+++ b/workbench/app/Enums/UnitEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum UnitEnum
+{
+    case BAR;
+    case FOO;
+}


### PR DESCRIPTION
I tried to install Ranger on a project and encountered an error because my project contains enums that are not backed. 

```
  ErrorException 

  Undefined property: App\Enums\MyEnum::$value

  at vendor/laravel/ranger/src/Collectors/Enums.php:27
     23▕      */
     24▕     protected function toComponent(string $enum): EnumComponent
     25▕     {
     26▕         $cases = collect($enum::cases())
  ➜  27▕             ->mapWithKeys(fn ($case) => [$case->name => $case->value])
     28▕             ->all();
     29▕ 
     30▕         $component = new EnumComponent($enum, $cases);
     31▕         $component->setFilePath((new ReflectionClass($enum))->getFileName());
```

While looking into the issue I also noticed that `Laravel\Ranger\Components\Enum` was typed as expecting `array<string, string>` for cases which would be incorrect for integer backed enums.

I've added support for unit enums, test cases for unit enums and numeric enums, and updated the typing of `Laravel\Ranger\Components\Enum`.

I opted for `null` as the value for unit enums, but I could also see an argument for using the `name` as the value so if that would be preferred I'd be happy to make that change.