### PR TITLE
Fix integer id seen as string

### DIFF
--- a/src/Support/RouteParameter.php
+++ b/src/Support/RouteParameter.php
@@ -43,6 +43,11 @@ class RouteParameter
             return $default;
         }
 
+        if (str_contains($type, 'int')) {
+            // Handle int2, int4, int8, etc.
+            $type = 'int';
+        }
+
         return [Type::from($type)];
     }
 }


### PR DESCRIPTION
Integers in database are not exactly `int` but could be `smallint`, `int4`, `int8`, etc...
For example, in a default Laravel installation with Postgres, the `id` is an `int8`.

Fix https://github.com/laravel/wayfinder/issues/146

Thanks for your work.