### PR TITLE
Strip base path from route and controller file names

### DIFF
--- a/src/Components/Route.php
+++ b/src/Components/Route.php
@@ -187,14 +187,14 @@ class Route
                 return '[serialized-closure]';
             }
 
-            return $path;
+            return str_replace(base_path(), '', $path);
         }
 
         if (! class_exists($controller)) {
             return '[unknown]';
         }
 
-        return (new ReflectionClass($controller))->getFileName();
+        return str_replace(base_path(), '', (new ReflectionClass($controller))->getFileName());
     }
 
     protected function resolveUri(): string


### PR DESCRIPTION
Hi,

When generating docblocs for wayfinder, it writes the absolute path of the file, including the location of the file in the local computer. With this PR, the useless part is removed, to only keep the interesting part, inside the project.

```diff
- @see /Users/mathieutu/Projects/my-project/routes/web.php:32
+ @see /routes/web.php:32
```

Thanks,
Mathieu.
