### PR TITLE
fix(broadcast-events): support ShouldBroadcastNow alongside ShouldBroadcast

### DIFF
--- a/src/Collectors/BroadcastEvents.php
+++ b/src/Collectors/BroadcastEvents.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ranger\Collectors;
 
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\BroadcastEvent;
 use Laravel\Surveyor\Analyzed\ClassResult;
@@ -10,6 +11,7 @@ use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\Type;
 use Spatie\StructureDiscoverer\Discover;
+use Spatie\StructureDiscoverer\Support\Conditions\ConditionBuilder;
 
 class BroadcastEvents extends Collector
 {
@@ -24,8 +26,10 @@ class BroadcastEvents extends Collector
     public function collect(): Collection
     {
         $discovered = Discover::in(...$this->appPaths)
-            ->classes()
-            ->implementing(ShouldBroadcast::class)
+            ->any(
+                ConditionBuilder::create()->classes()->implementing(ShouldBroadcast::class),
+                ConditionBuilder::create()->classes()->implementing(ShouldBroadcastNow::class),
+            )
             ->get();
 
         return collect($discovered)

--- a/tests/Feature/BroadcastEventsTest.php
+++ b/tests/Feature/BroadcastEventsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Events\PostCreated;
+use App\Events\PostUpdated;
 use App\Events\UserCreated;
 use App\Events\UserUpdated;
 use Laravel\Ranger\Collectors\BroadcastEvents;
@@ -15,7 +16,7 @@ describe('broadcast event collection', function () {
         $events = $this->collector->collect();
 
         expect($events)->not->toBeEmpty();
-        expect($events)->toHaveCount(3);
+        expect($events)->toHaveCount(4);
     });
 
     it('finds UserCreated event', function () {
@@ -24,6 +25,14 @@ describe('broadcast event collection', function () {
 
         expect($userCreated)->not->toBeNull();
         expect($userCreated)->toBeInstanceOf(BroadcastEvent::class);
+    });
+
+    it('finds PostUpdated event (implementing ShouldBroadcastNow)', function () {
+        $events = $this->collector->collect();
+        $postUpdated = $events->first(fn (BroadcastEvent $e) => $e->className === PostUpdated::class);
+
+        expect($postUpdated)->not->toBeNull();
+        expect($postUpdated)->toBeInstanceOf(BroadcastEvent::class);
     });
 
     it('finds UserUpdated event', function () {

--- a/workbench/app/Events/PostUpdated.php
+++ b/workbench/app/Events/PostUpdated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Post;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PostUpdated implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(protected Post $post)
+    {
+        //
+    }
+
+    public function broadcastOn(): array
+    {
+        return [
+            new Channel('posts'),
+            new PrivateChannel('users.'.$this->post->user_id),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'post' => $this->post->only(['id', 'title', 'created_at']),
+            'author' => $this->post->user->only(['id', 'name']),
+        ];
+    }
+}


### PR DESCRIPTION
Spatie’s structure discovery conditions are combined as AND by default, which prevented events implementing only ShouldBroadcastNow from being discovered.

Replace the collector logic with an OR condition using Discover::any() so that both ShouldBroadcast and ShouldBroadcastNow interfaces are recognized.

Added a test to verify the new behavior.

This should fix https://github.com/laravel/wayfinder/issues/162#issue-3853555957