### PR TITLE
Fix unit enum case values in Enums collector

### DIFF
--- a/src/Collectors/Enums.php
+++ b/src/Collectors/Enums.php
@@ -25,7 +25,7 @@ class Enums extends Collector
     protected function toComponent(string $enum): EnumComponent
     {
         $cases = collect($enum::cases())
-            ->mapWithKeys(fn ($case) => [$case->name => $case instanceof BackedEnum ? $case->value : null])
+            ->mapWithKeys(fn ($case, $index) => [$case->name => $case instanceof BackedEnum ? $case->value : (int) $index])
             ->all();
 
         $component = new EnumComponent($enum, $cases);

--- a/tests/Feature/EnumsTest.php
+++ b/tests/Feature/EnumsTest.php
@@ -80,8 +80,8 @@ it('captures unit enum cases correctly', function () {
 
     expect($userRole->cases)->toHaveCount(2);
     expect($userRole->cases)->toMatchArray([
-        'BAR' => null,
-        'FOO' => null,
+        'BAR' => 0,
+        'FOO' => 1,
     ]);
 });
 


### PR DESCRIPTION
Currently, when collecting enums, UnitEnum cases (PHP enums without explicit values) are mapped to null.

When generating TypeScript code from these enums, we were previously generating numeric values as strings (e.g., "1"), because UnitEnum cases had no proper numeric value.

For UnitEnum cases, the fix is returning return numeric indices (0, 1, 2…) based on the order of cases. BackedEnum cases continue to return their actual values.

This allows laravel wayfinder to generate UnitEnums like the following:
```typescript
export const None = 0
export const Open = 1
export const Done = 2
``` 

Instead of:
```typescript
export const None = "0"
export const Open = "1"
export const Done = "2"
``` 

The code diff:
```php
protected function toComponent(string $enum): EnumComponent
{
    $cases = collect($enum::cases())
        ->mapWithKeys(fn ($case, $index) => [
            $case->name => $case instanceof BackedEnum ? $case->value : (int) $index
        ])
        ->all();

    $component = new EnumComponent($enum, $cases);
    $component->setFilePath((new ReflectionClass($enum))->getFileName());

    return $component;
}
``` 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
