### PR TITLE
Collect API resource and arrayable responses

### DIFF
--- a/src/Collectors/InertiaComponents.php
+++ b/src/Collectors/InertiaComponents.php
@@ -3,10 +3,12 @@
 namespace Laravel\Ranger\Collectors;
 
 use Laravel\Ranger\Components\InertiaResponse;
+use Laravel\Surveyor\Analyzer\ArrayableResolver;
 use Laravel\Surveyor\Result\VariableState;
 use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\CallableType;
+use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
 
@@ -56,6 +58,13 @@ class InertiaComponents
         foreach ($data->value as $key => $value) {
             if ($value instanceof VariableState) {
                 $value = $value->type();
+            }
+
+            if (
+                $value instanceof ClassType
+                && $resolved = app(ArrayableResolver::class)->resolve($value)
+            ) {
+                $value = $resolved;
             }
 
             if (in_array($key, $same)) {

--- a/src/Collectors/InertiaComponents.php
+++ b/src/Collectors/InertiaComponents.php
@@ -55,6 +55,8 @@ class InertiaComponents
             }
         }
 
+        $resolver = app(ArrayableResolver::class);
+
         foreach ($data->value as $key => $value) {
             if ($value instanceof VariableState) {
                 $value = $value->type();
@@ -62,7 +64,7 @@ class InertiaComponents
 
             if (
                 $value instanceof ClassType
-                && $resolved = app(ArrayableResolver::class)->resolve($value)
+                && $resolved = $resolver->resolve($value)
             ) {
                 $value = $resolved;
             }

--- a/src/Collectors/Response.php
+++ b/src/Collectors/Response.php
@@ -9,7 +9,9 @@ use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Support\AnalyzesRoutes;
 use Laravel\Surveyor\Analyzed\MethodResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Analyzer\ArrayableResolver;
 use Laravel\Surveyor\Types\ArrayType;
+use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\MultiType;
 use Laravel\Surveyor\Types\Entities\InertiaRender;
 use Laravel\Surveyor\Types\Entities\JsonApiResourceResponse as SurveyorJsonApiResourceResponse;
@@ -40,6 +42,7 @@ class Response
             $this->getJsonResponse($result),
             $this->getResourceResponse($result),
             $this->getJsonApiResponse($result),
+            $this->getArrayableClassResponse($result),
         );
     }
 
@@ -102,6 +105,29 @@ class Response
             meta: $response->meta instanceof ArrayType ? $response->meta->value : [],
             isCollection: $response->isCollection,
         ), $responses);
+    }
+
+    protected function getArrayableClassResponse(MethodResult $result): array
+    {
+        $responses = $this->filterReturnTypesFor(
+            $result,
+            fn ($type) => $type instanceof ClassType
+                && ! $type instanceof InertiaRender
+                && ! $type instanceof SurveyorResourceResponse
+                && ! $type instanceof SurveyorJsonApiResourceResponse,
+        );
+
+        $resolved = [];
+
+        foreach ($responses as $classType) {
+            $arrayType = app(ArrayableResolver::class)->resolve($classType);
+
+            if ($arrayType instanceof ArrayType) {
+                $resolved[] = new JsonResponse($arrayType->value);
+            }
+        }
+
+        return $resolved;
     }
 
     protected function filterReturnTypesFor(MethodResult $result, Closure $filter): array

--- a/src/Collectors/Response.php
+++ b/src/Collectors/Response.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ranger\Collectors;
 
 use Closure;
+use Laravel\Ranger\Components\JsonApiResponse;
 use Laravel\Ranger\Components\JsonResponse;
 use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Support\AnalyzesRoutes;
@@ -11,6 +12,7 @@ use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\MultiType;
 use Laravel\Surveyor\Types\Entities\InertiaRender;
+use Laravel\Surveyor\Types\Entities\JsonApiResourceResponse as SurveyorJsonApiResourceResponse;
 use Laravel\Surveyor\Types\Entities\ResourceResponse as SurveyorResourceResponse;
 
 class Response
@@ -37,6 +39,7 @@ class Response
             $this->getInertiaResponse($result),
             $this->getJsonResponse($result),
             $this->getResourceResponse($result),
+            $this->getJsonApiResponse($result),
         );
     }
 
@@ -80,6 +83,24 @@ class Response
             isCollection: $response->isCollection,
             wrap: $response->wrap,
             additional: $response->additional instanceof ArrayType ? $response->additional->value : [],
+        ), $responses);
+    }
+
+    protected function getJsonApiResponse(MethodResult $result): array
+    {
+        /** @var SurveyorJsonApiResourceResponse[] $responses */
+        $responses = $this->filterReturnTypesFor(
+            $result,
+            fn ($type) => $type instanceof SurveyorJsonApiResourceResponse,
+        );
+
+        return array_map(fn ($response) => new JsonApiResponse(
+            resourceClass: $response->resourceClass,
+            attributes: $response->attributes instanceof ArrayType ? $response->attributes->value : [],
+            relationships: $response->relationships instanceof ArrayType ? $response->relationships->value : [],
+            links: $response->links instanceof ArrayType ? $response->links->value : [],
+            meta: $response->meta instanceof ArrayType ? $response->meta->value : [],
+            isCollection: $response->isCollection,
         ), $responses);
     }
 

--- a/src/Collectors/Response.php
+++ b/src/Collectors/Response.php
@@ -4,12 +4,14 @@ namespace Laravel\Ranger\Collectors;
 
 use Closure;
 use Laravel\Ranger\Components\JsonResponse;
+use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Support\AnalyzesRoutes;
 use Laravel\Surveyor\Analyzed\MethodResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\MultiType;
 use Laravel\Surveyor\Types\Entities\InertiaRender;
+use Laravel\Surveyor\Types\Entities\ResourceResponse as SurveyorResourceResponse;
 
 class Response
 {
@@ -34,6 +36,7 @@ class Response
         return array_merge(
             $this->getInertiaResponse($result),
             $this->getJsonResponse($result),
+            $this->getResourceResponse($result),
         );
     }
 
@@ -61,6 +64,23 @@ class Response
         );
 
         return array_map(fn ($response) => new JsonResponse($response->value), $responses);
+    }
+
+    protected function getResourceResponse(MethodResult $result): array
+    {
+        /** @var SurveyorResourceResponse[] $responses */
+        $responses = $this->filterReturnTypesFor(
+            $result,
+            fn ($type) => $type instanceof SurveyorResourceResponse,
+        );
+
+        return array_map(fn ($response) => new ResourceResponse(
+            resourceClass: $response->resourceClass,
+            data: $response->data instanceof ArrayType ? $response->data->value : [],
+            isCollection: $response->isCollection,
+            wrap: $response->wrap,
+            additional: $response->additional instanceof ArrayType ? $response->additional->value : [],
+        ), $responses);
     }
 
     protected function filterReturnTypesFor(MethodResult $result, Closure $filter): array

--- a/src/Collectors/Response.php
+++ b/src/Collectors/Response.php
@@ -27,7 +27,7 @@ class Response
     }
 
     /**
-     * @return list<InertiaResponse|JsonResponse>
+     * @return list<string|JsonResponse|ResourceResponse|JsonApiResponse>
      */
     public function parseResponse(array $action): array
     {
@@ -111,16 +111,14 @@ class Response
     {
         $responses = $this->filterReturnTypesFor(
             $result,
-            fn ($type) => $type instanceof ClassType
-                && ! $type instanceof InertiaRender
-                && ! $type instanceof SurveyorResourceResponse
-                && ! $type instanceof SurveyorJsonApiResourceResponse,
+            fn ($type) => get_class($type) === ClassType::class,
         );
 
+        $resolver = app(ArrayableResolver::class);
         $resolved = [];
 
         foreach ($responses as $classType) {
-            $arrayType = app(ArrayableResolver::class)->resolve($classType);
+            $arrayType = $resolver->resolve($classType);
 
             if ($arrayType instanceof ArrayType) {
                 $resolved[] = new JsonResponse($arrayType->value);

--- a/src/Components/JsonApiResponse.php
+++ b/src/Components/JsonApiResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ranger\Components;
+
+class JsonApiResponse
+{
+    public function __construct(
+        public readonly string $resourceClass,
+        public readonly array $attributes,
+        public readonly array $relationships,
+        public readonly array $links,
+        public readonly array $meta,
+        public readonly bool $isCollection,
+    ) {
+        //
+    }
+}

--- a/src/Components/ResourceResponse.php
+++ b/src/Components/ResourceResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ranger\Components;
+
+class ResourceResponse
+{
+    public function __construct(
+        public readonly string $resourceClass,
+        public readonly array $data,
+        public readonly bool $isCollection,
+        public readonly ?string $wrap,
+        public readonly array $additional = [],
+    ) {
+        //
+    }
+}

--- a/tests/Feature/ResponsesTest.php
+++ b/tests/Feature/ResponsesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Laravel\Ranger\Collectors\Routes;
+use Laravel\Ranger\Components\JsonApiResponse;
+use Laravel\Ranger\Components\JsonResponse;
+use Laravel\Ranger\Components\ResourceResponse;
+use Laravel\Ranger\Components\Route;
+
+beforeEach(function () {
+    $this->routes = app(Routes::class)->collect();
+});
+
+function ranger_route(string $name): Route
+{
+    return test()->routes->first(fn (Route $r) => $r->name() === $name);
+}
+
+describe('resource responses', function () {
+    it('captures Eloquent API resources', function () {
+        $route = ranger_route('resources.users.show');
+        $responses = $route->possibleResponses();
+
+        expect($responses)->toHaveCount(1);
+        expect($responses[0])->toBeInstanceOf(ResourceResponse::class);
+        expect($responses[0]->resourceClass)->toBe('App\\Http\\Resources\\UserResource');
+        expect($responses[0]->isCollection)->toBeFalse();
+        expect($responses[0]->wrap)->toBe('data');
+        expect(array_keys($responses[0]->data))->toEqual(['id', 'name', 'email']);
+    });
+
+    it('captures Eloquent API resource collections', function () {
+        $route = ranger_route('resources.users.index');
+        $responses = $route->possibleResponses();
+
+        expect($responses)->toHaveCount(1);
+        expect($responses[0])->toBeInstanceOf(ResourceResponse::class);
+        expect($responses[0]->resourceClass)->toBe('App\\Http\\Resources\\UserResource');
+        expect($responses[0]->isCollection)->toBeTrue();
+    });
+
+    it('captures JSON:API resource responses', function () {
+        $route = ranger_route('resources.users.json-api');
+        $responses = $route->possibleResponses();
+
+        expect($responses)->toHaveCount(1);
+        expect($responses[0])->toBeInstanceOf(JsonApiResponse::class);
+        expect($responses[0]->resourceClass)->toBe('App\\Http\\Resources\\UserJsonApiResource');
+        expect($responses[0]->isCollection)->toBeFalse();
+        expect(array_keys($responses[0]->attributes))->toEqual(['name', 'email']);
+    });
+
+    it('captures arrayable DTOs as JSON responses', function () {
+        $route = ranger_route('resources.checkout');
+        $responses = $route->possibleResponses();
+
+        expect($responses)->toHaveCount(1);
+        expect($responses[0])->toBeInstanceOf(JsonResponse::class);
+        expect(array_keys($responses[0]->data))->toEqual(['total', 'currency']);
+    });
+
+    it('ignores classes that are not arrayable', function () {
+        $route = ranger_route('resources.plain');
+
+        expect($route->possibleResponses())->toBe([]);
+    });
+});

--- a/tests/Unit/ComponentsTest.php
+++ b/tests/Unit/ComponentsTest.php
@@ -6,8 +6,10 @@ use Laravel\Ranger\Components\Enum;
 use Laravel\Ranger\Components\EnvironmentVariable;
 use Laravel\Ranger\Components\InertiaResponse;
 use Laravel\Ranger\Components\InertiaSharedData;
+use Laravel\Ranger\Components\JsonApiResponse;
 use Laravel\Ranger\Components\JsonResponse;
 use Laravel\Ranger\Components\Model;
+use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Components\Validator;
 use Laravel\Ranger\Support\Verb;
 use Laravel\Surveyor\Types\ArrayType;
@@ -154,6 +156,78 @@ describe('JsonResponse component', function () {
         $response = new JsonResponse($data);
 
         expect($response->data)->toBe($data);
+    });
+});
+
+describe('ResourceResponse component', function () {
+    it('can be instantiated with full attributes', function () {
+        $data = ['id' => new StringType, 'name' => new StringType];
+        $additional = ['version' => new StringType];
+
+        $response = new ResourceResponse(
+            resourceClass: 'App\\Http\\Resources\\UserResource',
+            data: $data,
+            isCollection: false,
+            wrap: 'data',
+            additional: $additional,
+        );
+
+        expect($response->resourceClass)->toBe('App\\Http\\Resources\\UserResource');
+        expect($response->data)->toBe($data);
+        expect($response->isCollection)->toBeFalse();
+        expect($response->wrap)->toBe('data');
+        expect($response->additional)->toBe($additional);
+    });
+
+    it('supports collection and null wrap', function () {
+        $response = new ResourceResponse(
+            resourceClass: 'App\\Http\\Resources\\UserResource',
+            data: ['id' => new StringType],
+            isCollection: true,
+            wrap: null,
+        );
+
+        expect($response->isCollection)->toBeTrue();
+        expect($response->wrap)->toBeNull();
+        expect($response->additional)->toBe([]);
+    });
+});
+
+describe('JsonApiResponse component', function () {
+    it('can be instantiated with all sections', function () {
+        $attributes = ['name' => new StringType];
+        $relationships = ['posts' => new StringType];
+        $links = ['self' => new StringType];
+        $meta = ['count' => new StringType];
+
+        $response = new JsonApiResponse(
+            resourceClass: 'App\\JsonApi\\UserResource',
+            attributes: $attributes,
+            relationships: $relationships,
+            links: $links,
+            meta: $meta,
+            isCollection: false,
+        );
+
+        expect($response->resourceClass)->toBe('App\\JsonApi\\UserResource');
+        expect($response->attributes)->toBe($attributes);
+        expect($response->relationships)->toBe($relationships);
+        expect($response->links)->toBe($links);
+        expect($response->meta)->toBe($meta);
+        expect($response->isCollection)->toBeFalse();
+    });
+
+    it('supports collection responses', function () {
+        $response = new JsonApiResponse(
+            resourceClass: 'App\\JsonApi\\UserResource',
+            attributes: ['name' => new StringType],
+            relationships: [],
+            links: [],
+            meta: [],
+            isCollection: true,
+        );
+
+        expect($response->isCollection)->toBeTrue();
     });
 });
 

--- a/workbench/app/Http/Controllers/ResourceController.php
+++ b/workbench/app/Http/Controllers/ResourceController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\UserJsonApiResource;
+use App\Http\Resources\UserResource;
+use App\Models\User;
+use App\Support\CheckoutSummary;
+
+class ResourceController
+{
+    public function show(User $user): UserResource
+    {
+        return new UserResource($user);
+    }
+
+    public function index()
+    {
+        return UserResource::collection(User::all());
+    }
+
+    public function jsonApi(User $user): UserJsonApiResource
+    {
+        return new UserJsonApiResource($user);
+    }
+
+    public function summary(): CheckoutSummary
+    {
+        return new CheckoutSummary(100, 'USD');
+    }
+
+    public function plain(): \stdClass
+    {
+        return new \stdClass;
+    }
+}

--- a/workbench/app/Http/Resources/UserJsonApiResource.php
+++ b/workbench/app/Http/Resources/UserJsonApiResource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class UserJsonApiResource extends JsonApiResource
+{
+    public static $type = 'users';
+
+    public static $attributes = ['name', 'email'];
+}

--- a/workbench/app/Http/Resources/UserResource.php
+++ b/workbench/app/Http/Resources/UserResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/workbench/app/Support/CheckoutSummary.php
+++ b/workbench/app/Support/CheckoutSummary.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class CheckoutSummary implements Arrayable
+{
+    public function __construct(
+        public readonly int $total,
+        public readonly string $currency,
+    ) {
+        //
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'total' => $this->total,
+            'currency' => $this->currency,
+        ];
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Nested\NestedController;
 use App\Http\Controllers\OptionalController;
 use App\Http\Controllers\ParameterNameController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\ResourceController;
 use App\Http\Controllers\TwoRoutesSameActionController;
 use App\Http\Controllers\UrlDefaultsController;
 use App\Http\Middleware\UrlDefaultsMiddleware;
@@ -73,6 +74,12 @@ Route::get('/anonymous-middleware', [AnonymousMiddlewareController::class, 'show
 Route::get('/package-route', function () {
     //
 })->name('my-package::store');
+
+Route::get('/resources/users/{user}', [ResourceController::class, 'show'])->name('resources.users.show');
+Route::get('/resources/users', [ResourceController::class, 'index'])->name('resources.users.index');
+Route::get('/resources/users/{user}/json-api', [ResourceController::class, 'jsonApi'])->name('resources.users.json-api');
+Route::get('/resources/checkout', [ResourceController::class, 'summary'])->name('resources.checkout');
+Route::get('/resources/plain', [ResourceController::class, 'plain'])->name('resources.plain');
 
 Route::prefix('/api/v1')->name('api.v1.')->group(function () {
     Route::get('/tasks', fn () => 'ok')->name('tasks');


### PR DESCRIPTION
Picks up three new return types when collecting route responses: Eloquent API resources, JSON:API resources, and any arrayable class. Inertia prop collection also runs class types through the ArrayableResolver so toArray-style props get unwrapped into their underlying shape.