### PR TITLE
Resolve route binding types via Surveyor analyzer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/routing": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/pint": "^1.22",
-        "laravel/surveyor": "^0.1.0",
+        "laravel/surveyor": "^0.2.1",
         "nikic/php-parser": "^5.4",
         "phpstan/phpdoc-parser": "^2.1",
         "spatie/php-structure-discoverer": "^2.3"

--- a/src/Support/RouteBindingResolver.php
+++ b/src/Support/RouteBindingResolver.php
@@ -3,15 +3,17 @@
 namespace Laravel\Ranger\Support;
 
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Surveyor\Analyzer\Analyzer;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 
 class RouteBindingResolver
 {
     protected static $booted = [];
 
-    protected static $columns = [];
+    protected static $analyzed = [];
 
     /**
-     * @return array{type: string|null, key: string}
+     * @return array{0: TypeContract|null, 1: string|null}
      */
     public static function resolveTypeAndKey(string $routable, $key): array
     {
@@ -23,12 +25,12 @@ class RouteBindingResolver
             return [null, $key];
         }
 
-        self::$columns[$routable] ??= $booted->getConnection()->getSchemaBuilder()->getColumns($booted->getTable());
+        $result = self::$analyzed[$routable] ??= app(Analyzer::class)->analyzeClass($routable)->result();
 
-        $firstColumn = collect(self::$columns[$routable])->first(
-            fn ($column) => $column['name'] === $key,
-        );
+        if ($result === null || ! $result->hasProperty($key)) {
+            return [null, $key];
+        }
 
-        return [$firstColumn['type_name'] ?? null, $key];
+        return [$result->getProperty($key)->type, $key];
     }
 }

--- a/src/Support/RouteParameter.php
+++ b/src/Support/RouteParameter.php
@@ -43,11 +43,6 @@ class RouteParameter
             return $default;
         }
 
-        if (str_contains($type, 'int')) {
-            // Handle int2, int4, int8, etc.
-            $type = 'int';
-        }
-
-        return [Type::from($type)];
+        return [$type];
     }
 }

--- a/tests/Unit/ParameterTest.php
+++ b/tests/Unit/ParameterTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use App\Models\DocBlockBinding;
+use App\Models\User;
 use Laravel\Ranger\Support\RouteParameter;
+use Laravel\Surveyor\Types\IntType;
+use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
 
 describe('Parameter component', function () {
@@ -41,5 +45,40 @@ describe('Parameter component', function () {
         $param = new RouteParameter('id', false, null, null);
 
         expect($param->types)->toEqual([Type::string(), Type::number()]);
+    });
+
+    it('resolves bound model parameter type from the database schema', function () {
+        $reflection = new ReflectionFunction(fn (User $user) => null);
+        $bound = $reflection->getParameters()[0];
+
+        $param = new RouteParameter('user', false, null, null, $bound);
+
+        expect($param->types)->toHaveCount(1);
+        expect($param->types[0])->toBeInstanceOf(IntType::class);
+        expect($param->key)->toBe('id');
+    });
+
+    it('falls back to model docblock @property tags when the schema is unavailable', function () {
+        // DocBlockBinding points at a table that does not exist in migrations,
+        // so ModelInspector throws and only the @property docblock is available.
+        $reflection = new ReflectionFunction(fn (DocBlockBinding $binding) => null);
+        $bound = $reflection->getParameters()[0];
+
+        $param = new RouteParameter('binding', false, null, null, $bound);
+
+        expect($param->types)->toHaveCount(1);
+        expect($param->types[0])->toBeInstanceOf(IntType::class);
+        expect($param->key)->toBe('id');
+    });
+
+    it('resolves an explicit string key via the model docblock', function () {
+        $reflection = new ReflectionFunction(fn (DocBlockBinding $binding) => null);
+        $bound = $reflection->getParameters()[0];
+
+        $param = new RouteParameter('binding', false, 'slug', null, $bound);
+
+        expect($param->types)->toHaveCount(1);
+        expect($param->types[0])->toBeInstanceOf(StringType::class);
+        expect($param->key)->toBe('slug');
     });
 });

--- a/workbench/app/Models/DocBlockBinding.php
+++ b/workbench/app/Models/DocBlockBinding.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $slug
+ */
+class DocBlockBinding extends Model
+{
+    protected $table = 'doc_block_bindings_no_table';
+}


### PR DESCRIPTION
Switches RouteBindingResolver from raw schema column inspection to Surveyor's Analyzer, so models whose table isn't available (e.g. external data sources, unmigrated test fixtures) still get their key types resolved through @property docblocks. Drops the now-redundant int2/int4/int8 normalization since Surveyor returns proper Type instances.

Fixes https://github.com/laravel/ranger/issues/23