### PR TITLE
Surface JSON:API resource additional data

### DIFF
--- a/src/Collectors/Response.php
+++ b/src/Collectors/Response.php
@@ -104,6 +104,7 @@ class Response
             links: $response->links instanceof ArrayType ? $response->links->value : [],
             meta: $response->meta instanceof ArrayType ? $response->meta->value : [],
             isCollection: $response->isCollection,
+            additional: $response->additional instanceof ArrayType ? $response->additional->value : [],
         ), $responses);
     }
 

--- a/src/Components/JsonApiResponse.php
+++ b/src/Components/JsonApiResponse.php
@@ -11,6 +11,7 @@ class JsonApiResponse
         public readonly array $links,
         public readonly array $meta,
         public readonly bool $isCollection,
+        public readonly array $additional = [],
     ) {
         //
     }

--- a/tests/Feature/ResponsesTest.php
+++ b/tests/Feature/ResponsesTest.php
@@ -47,6 +47,7 @@ describe('resource responses', function () {
         expect($responses[0]->resourceClass)->toBe('App\\Http\\Resources\\UserJsonApiResource');
         expect($responses[0]->isCollection)->toBeFalse();
         expect(array_keys($responses[0]->attributes))->toEqual(['name', 'email']);
+        expect(array_keys($responses[0]->additional))->toEqual(['version']);
     });
 
     it('captures arrayable DTOs as JSON responses', function () {

--- a/tests/Unit/ComponentsTest.php
+++ b/tests/Unit/ComponentsTest.php
@@ -199,6 +199,7 @@ describe('JsonApiResponse component', function () {
         $relationships = ['posts' => new StringType];
         $links = ['self' => new StringType];
         $meta = ['count' => new StringType];
+        $additional = ['version' => new StringType];
 
         $response = new JsonApiResponse(
             resourceClass: 'App\\JsonApi\\UserResource',
@@ -207,6 +208,7 @@ describe('JsonApiResponse component', function () {
             links: $links,
             meta: $meta,
             isCollection: false,
+            additional: $additional,
         );
 
         expect($response->resourceClass)->toBe('App\\JsonApi\\UserResource');
@@ -215,6 +217,7 @@ describe('JsonApiResponse component', function () {
         expect($response->links)->toBe($links);
         expect($response->meta)->toBe($meta);
         expect($response->isCollection)->toBeFalse();
+        expect($response->additional)->toBe($additional);
     });
 
     it('supports collection responses', function () {
@@ -228,6 +231,7 @@ describe('JsonApiResponse component', function () {
         );
 
         expect($response->isCollection)->toBeTrue();
+        expect($response->additional)->toBe([]);
     });
 });
 

--- a/workbench/app/Http/Resources/UserJsonApiResource.php
+++ b/workbench/app/Http/Resources/UserJsonApiResource.php
@@ -9,4 +9,11 @@ class UserJsonApiResource extends JsonApiResource
     public static $type = 'users';
 
     public static $attributes = ['name', 'email'];
+
+    public function with($request)
+    {
+        return [
+            'version' => '1.0',
+        ];
+    }
 }


### PR DESCRIPTION
Surveyor already resolves a JSON:API resource's `with()` payload into the `additional` field on its `JsonApiResourceResponse`, but Ranger was dropping it. This threads it through to `Components\JsonApiResponse` so consumers can read it alongside attributes, relationships, links, and meta (matching how the regular `ResourceResponse` already behaves).