### PR TITLE
Skip JsonResource subclasses in arrayable fallback

### DIFF
--- a/src/Collectors/Response.php
+++ b/src/Collectors/Response.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ranger\Collectors;
 
 use Closure;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Ranger\Components\JsonApiResponse;
 use Laravel\Ranger\Components\JsonResponse;
 use Laravel\Ranger\Components\ResourceResponse;
@@ -112,7 +113,8 @@ class Response
     {
         $responses = $this->filterReturnTypesFor(
             $result,
-            fn ($type) => get_class($type) === ClassType::class,
+            fn ($type) => get_class($type) === ClassType::class
+                && ! is_a($type->resolved(), JsonResource::class, true),
         );
 
         $resolver = app(ArrayableResolver::class);

--- a/tests/Feature/ResponsesTest.php
+++ b/tests/Feature/ResponsesTest.php
@@ -38,6 +38,15 @@ describe('resource responses', function () {
         expect($responses[0]->isCollection)->toBeTrue();
     });
 
+    it('does not duplicate Eloquent resource responses when the controller declares JsonResource as the return type', function () {
+        $route = ranger_route('resources.users.show-as-base');
+        $responses = $route->possibleResponses();
+
+        expect($responses)->toHaveCount(1);
+        expect($responses[0])->toBeInstanceOf(ResourceResponse::class);
+        expect($responses[0]->resourceClass)->toBe('App\\Http\\Resources\\UserResource');
+    });
+
     it('captures JSON:API resource responses', function () {
         $route = ranger_route('resources.users.json-api');
         $responses = $route->possibleResponses();

--- a/workbench/app/Http/Controllers/ResourceController.php
+++ b/workbench/app/Http/Controllers/ResourceController.php
@@ -6,6 +6,7 @@ use App\Http\Resources\UserJsonApiResource;
 use App\Http\Resources\UserResource;
 use App\Models\User;
 use App\Support\CheckoutSummary;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class ResourceController
 {
@@ -17,6 +18,11 @@ class ResourceController
     public function index()
     {
         return UserResource::collection(User::all());
+    }
+
+    public function showAsBase(User $user): JsonResource
+    {
+        return new UserResource($user);
     }
 
     public function jsonApi(User $user): UserJsonApiResource

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -80,6 +80,7 @@ Route::get('/package-route', function () {
 
 Route::get('/resources/users/{user}', [ResourceController::class, 'show'])->name('resources.users.show');
 Route::get('/resources/users', [ResourceController::class, 'index'])->name('resources.users.index');
+Route::get('/resources/users/{user}/base', [ResourceController::class, 'showAsBase'])->name('resources.users.show-as-base');
 Route::get('/resources/users/{user}/json-api', [ResourceController::class, 'jsonApi'])->name('resources.users.json-api');
 Route::get('/resources/checkout', [ResourceController::class, 'summary'])->name('resources.checkout');
 Route::get('/resources/plain', [ResourceController::class, 'plain'])->name('resources.plain');


### PR DESCRIPTION
Skip JsonResource subclasses in arrayable fallback

When a controller declares `: JsonResource` as the return type, Surveyor records two return types — the declared `ClassType('JsonResource')` plus the `SurveyorResourceResponse` from the `return` statement. Both flowed through `parseResponse`: `getResourceResponse` produced the real `{ data: {...} }` shape, and `getArrayableClassResponse` *also* matched the bare `ClassType('JsonResource')` and resolved its declared `jsonSerialize(): array` to an empty `ArrayType`. Downstream that surfaced as a `Record<string, never>` branch unioned onto every Resource response type.

Filters JsonResource subclasses (which covers `JsonResource`, `ResourceCollection`, `AnonymousResourceCollection`, `JsonApiResource`, and user subclasses) out of `getArrayableClassResponse`, since they're already handled by `getResourceResponse` / `getJsonApiResponse`.

Adds a regression test covering a controller method declared `: JsonResource` — fails on `main` (count 2), passes here (count 1).
