### PR TITLE
Merge APP_URL port into explicit Route::domain URIs

### DIFF
--- a/src/Components/Route.php
+++ b/src/Components/Route.php
@@ -227,8 +227,8 @@ class Route
             $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
         }
 
-        if (($domain = $this->domain()) !== null && $this->base->getDomain() === null) {
-            $uri = ($this->scheme() ?? '//').$domain.$uri;
+        if (($domain = $this->domain()) !== null) {
+            $uri = ($this->scheme() ?? '//').$this->mergeDomainPort($domain).$uri;
         }
 
         $uri = str($uri)
@@ -267,6 +267,21 @@ class Route
         $path = '/'.trim($parts['path'], '/');
 
         return $path === '/' ? '' : $path;
+    }
+
+    protected function mergeDomainPort(string $domain): string
+    {
+        if (str_contains($domain, ':')) {
+            return $domain;
+        }
+
+        $parts = $this->getParsedRoot();
+
+        if (! isset($parts['port'])) {
+            return $domain;
+        }
+
+        return $domain.':'.$parts['port'];
     }
 
     protected function getParsedRoot(): array

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -281,7 +281,7 @@ describe('APP_URL base path and port resolution', function () {
         expect($postsRoute->uri())->toBe('http://localhost:8081/v2/posts');
     });
 
-    it('returns relative URIs for explicit Route::domain routes even when forcedRoot is set', function () {
+    it('merges scheme and port from forcedRoot into explicit Route::domain URIs', function () {
         app('url')->forceRootUrl('https://localhost:8001');
         app()->forgetInstance(Routes::class);
 
@@ -290,20 +290,30 @@ describe('APP_URL base path and port resolution', function () {
         $fixedDomainRoute = $routes->first(fn (Route $r) => str_contains($r->uri(), 'fixed-domain'));
         $defaultDomainRoute = $routes->first(fn (Route $r) => str_contains($r->uri(), 'default-parameters-domain'));
 
-        expect($fixedDomainRoute->uri())->toBe('/fixed-domain/{param}');
-        expect($defaultDomainRoute->uri())->toBe('/default-parameters-domain/{param}');
+        expect($fixedDomainRoute->uri())->toBe('https://example.test:8001/fixed-domain/{param}');
+        expect($defaultDomainRoute->uri())->toBe('https://{defaultDomain?}.au:8001/default-parameters-domain/{param}');
     });
 
-    it('returns relative URIs for explicit Route::domain routes with no forcedRoot', function () {
+    it('returns protocol-relative URIs for explicit Route::domain routes when APP_URL has no port', function () {
         $fixedDomainRoute = $this->routes->first(fn (Route $r) => str_contains($r->uri(), 'fixed-domain'));
         $dynamicDomainRoute = $this->routes->first(fn (Route $r) => str_contains($r->uri(), 'dynamic-domain'));
 
-        expect($fixedDomainRoute->uri())->toBe('/fixed-domain/{param}');
-        expect($dynamicDomainRoute->uri())->toBe('/dynamic-domain/{param}');
+        expect($fixedDomainRoute->uri())->toBe('//example.test/fixed-domain/{param}');
+        expect($dynamicDomainRoute->uri())->toBe('//{domain}.au/dynamic-domain/{param}');
 
-        // The routing-level domain metadata is still preserved for consumers that need it.
+        // The routing-level domain metadata is preserved for consumers that need it.
         expect($fixedDomainRoute->domain())->toBe('example.test');
         expect($dynamicDomainRoute->domain())->toBe('{domain}.au');
+    });
+
+    it('merges port from APP_URL into explicit Route::domain URIs', function () {
+        app('url')->forceRootUrl('http://assets.localhost:8000');
+        app()->forgetInstance(Routes::class);
+
+        $routes = app(Routes::class)->collect();
+        $fixedDomainRoute = $routes->first(fn (Route $r) => str_contains($r->uri(), 'fixed-domain'));
+
+        expect($fixedDomainRoute->uri())->toBe('http://example.test:8000/fixed-domain/{param}');
     });
 
     it('does not prefix when APP_URL has no path', function () {


### PR DESCRIPTION
- `Route::resolveUri()` now prefixes explicit-domain routes with `scheme://host:port/path`, mirroring what Laravel's URL generator produces for the same route.
- The port is pulled from APP_URL (or `forceRootUrl(...)`) via a new `mergeDomainPort()` helper, and skipped when the explicit domain already declares its own port.
- `Route::domain()` is unchanged — it still returns the bare routing-level metadata for consumers that want it.

## Background
#26 fixed a real bug: protocol-relative `//control.localhost/dashboard` resolves to port 80 in browsers, so with `APP_URL=http://assets.localhost:8000` the port was silently dropped and same-origin dev navigation broke. The fix there was to emit a relative path for explicit-domain routes.

That side-stepped the symptom but left `Route::uri()` diverging from what `route('foo')` returns in Laravel: Laravel's URL generator merges APP_URL's port into the route domain (`http://control.localhost:8000/dashboard`), so consumers like Wayfinder that pattern-match `uri()` get a different shape than they'd get from the framework. The actual missing piece was the port merge, not the host prefix.

This change keeps Ben's port-loss case fixed (the URI now carries `:8000` explicitly so browsers can't drop it) while restoring the host so introspection consumers see the full URI Laravel would generate.