### PR TITLE
Handle UnionType in InertiaComponents merge

### DIFF
--- a/src/Collectors/InertiaComponents.php
+++ b/src/Collectors/InertiaComponents.php
@@ -9,6 +9,7 @@ use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\CallableType;
 use Laravel\Surveyor\Types\ClassType;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
 
@@ -19,8 +20,20 @@ class InertiaComponents
      */
     protected static array $components = [];
 
-    public static function addComponent(string $component, ArrayType|ArrayShapeType $data): void
+    public static function addComponent(string $component, TypeContract $data): void
     {
+        if ($data instanceof UnionType) {
+            foreach ($data->types as $type) {
+                self::addComponent($component, $type);
+            }
+
+            return;
+        }
+
+        if (! $data instanceof ArrayType && ! $data instanceof ArrayShapeType) {
+            return;
+        }
+
         $data = $data instanceof ArrayShapeType ? new ArrayType([]) : $data;
 
         self::$components[$component] = self::mergeComponentData($component, self::getComponentData($component), $data);
@@ -80,11 +93,10 @@ class InertiaComponents
                 $existingData[$key] = $value;
             }
 
-            if ($value instanceof ArrayType) {
-                $existingValue = $existingData[$key] ?? [];
+            if ($value instanceof ArrayType && ($existingData[$key] ?? null) instanceof ArrayType) {
                 $newValue = self::mergeComponentData(
                     $component,
-                    $existingValue instanceof ArrayType ? $existingValue->value : $existingValue,
+                    $existingData[$key]->value,
                     $value,
                 );
 

--- a/tests/Unit/InertiaComponentsTest.php
+++ b/tests/Unit/InertiaComponentsTest.php
@@ -8,6 +8,7 @@ use Laravel\Surveyor\Types\BoolType;
 use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
+use Laravel\Surveyor\Types\UnionType;
 
 beforeEach(function () {
     $reflection = new ReflectionClass(InertiaComponents::class);
@@ -87,6 +88,46 @@ describe('InertiaComponents static class', function () {
 
         // canRegister is only in first route, should be optional
         expect($stats['canRegister']->isOptional())->toBeTrue();
+    });
+
+    it('merges a prop whose type changes between an array and a non-array across renders', function () {
+        // Route 1: todaySchedules is some non-array (e.g. fallback empty string)
+        $data1 = new ArrayType([
+            'todaySchedules' => new StringType,
+        ]);
+
+        // Route 2: todaySchedules is a populated array shape
+        $data2 = new ArrayType([
+            'todaySchedules' => new ArrayType([
+                'id' => new IntType,
+            ]),
+        ]);
+
+        InertiaComponents::addComponent('Dashboard', $data1);
+        InertiaComponents::addComponent('Dashboard', $data2);
+
+        $component = InertiaComponents::getComponent('Dashboard');
+
+        expect($component->data)->toHaveKey('todaySchedules');
+        expect($component->data['todaySchedules'])->toBeInstanceOf(UnionType::class);
+    });
+
+    it('accepts a union type as the top-level component data', function () {
+        // e.g. Inertia::render('Foo', $cond ? ['a' => 1] : ['b' => 2])
+        // surveyor reports the data argument as a union of array shapes.
+        $data = Type::union(
+            new ArrayType(['a' => new IntType]),
+            new ArrayType(['b' => new StringType]),
+        );
+
+        InertiaComponents::addComponent('Foo', $data);
+
+        $component = InertiaComponents::getComponent('Foo');
+
+        expect($component->data)->toHaveKey('a');
+        expect($component->data)->toHaveKey('b');
+        expect($component->data['a']->isOptional())->toBeTrue();
+        expect($component->data['b']->isOptional())->toBeTrue();
     });
 
     it('merges nested array shape props correctly', function () {


### PR DESCRIPTION
Two TypeError crashes when generating types for Inertia components whose props vary across code paths.

The first happens when a component is rendered with different shapes in different branches (e.g. a Collection in one path, an array in another). After unioning the differing prop types, the nested array merge then passed that UnionType into mergeComponentData, which is typed array. Now we only recurse when the existing value is still an ArrayType.

The second happens when Inertia::render is called with a conditional data argument, so Surveyor reports the data as a UnionType. addComponent only accepted ArrayType|ArrayShapeType. It now accepts any Type, unwraps unions, and adds each ArrayType/ArrayShapeType member individually (mirroring multiple render calls).

Fixes laravel/wayfinder#168
