### PR TITLE
Respect $hidden, $visible, and $appends on model components

### DIFF
--- a/src/Collectors/Models.php
+++ b/src/Collectors/Models.php
@@ -22,8 +22,8 @@ use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\BoolType;
 use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as SurveyorTypeContract;
-use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
+use ReflectionClass;
 use Spatie\StructureDiscoverer\Discover;
 
 class Models extends Collector
@@ -75,8 +75,11 @@ class Models extends Collector
 
         $modelComponent = new ModelComponent($model);
 
-        $eagerLoadRelations = $this->gatherEagerLoadRelations($result);
+        $eagerLoadRelations = $this->getModelArrayProperty($model, 'with');
         $modelComponent->setSnakeCaseAttributes($this->shouldSnakeCase($result));
+        $modelComponent->setHidden($this->getModelArrayProperty($model, 'hidden'));
+        $modelComponent->setVisible($this->getModelArrayProperty($model, 'visible'));
+        $modelComponent->setAppends($this->getModelArrayProperty($model, 'appends'));
 
         $this->modelComponents->offsetSet($modelComponent->name, $modelComponent);
         $modelComponent->setFilePath($result->filePath());
@@ -104,23 +107,19 @@ class Models extends Collector
         }
     }
 
-    protected function gatherEagerLoadRelations(ClassResult $result): array
+    /**
+     * @param  class-string<Model>  $model
+     * @return list<string>
+     */
+    protected function getModelArrayProperty(string $model, string $propertyName): array
     {
-        $propertyName = 'with';
+        $defaults = (new ReflectionClass($model))->getDefaultProperties();
 
-        if (! $result->hasProperty($propertyName) || ! $result->getProperty($propertyName)->type instanceof ArrayType) {
+        if (! array_key_exists($propertyName, $defaults) || ! is_array($defaults[$propertyName])) {
             return [];
         }
 
-        $eagerLoadRelations = [];
-
-        foreach ($result->getProperty($propertyName)->type->value as $relation) {
-            if ($relation instanceof StringType) {
-                $eagerLoadRelations[] = $relation->value;
-            }
-        }
-
-        return $eagerLoadRelations;
+        return array_values(array_filter($defaults[$propertyName], 'is_string'));
     }
 
     protected function shouldSnakeCase(ClassResult $result): bool

--- a/src/Components/Model.php
+++ b/src/Components/Model.php
@@ -19,6 +19,21 @@ class Model
      */
     protected array $relations = [];
 
+    /**
+     * @var list<string>
+     */
+    protected array $hidden = [];
+
+    /**
+     * @var list<string>
+     */
+    protected array $visible = [];
+
+    /**
+     * @var list<string>
+     */
+    protected array $appends = [];
+
     protected bool $snakeCaseAttributes = true;
 
     public function __construct(public readonly string $name)
@@ -60,5 +75,75 @@ class Model
     public function addRelation(string $name, Type $type): void
     {
         $this->relations[$name] = $type;
+    }
+
+    /**
+     * @param  list<string>  $hidden
+     */
+    public function setHidden(array $hidden): void
+    {
+        $this->hidden = $hidden;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getHidden(): array
+    {
+        return $this->hidden;
+    }
+
+    /**
+     * @param  list<string>  $visible
+     */
+    public function setVisible(array $visible): void
+    {
+        $this->visible = $visible;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getVisible(): array
+    {
+        return $this->visible;
+    }
+
+    /**
+     * @param  list<string>  $appends
+     */
+    public function setAppends(array $appends): void
+    {
+        $this->appends = $appends;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getAppends(): array
+    {
+        return $this->appends;
+    }
+
+    /**
+     * Attributes and relations filtered through Eloquent's $visible/$hidden
+     * serialization rules. $visible acts as a whitelist when non-empty;
+     * otherwise $hidden removes the listed keys.
+     *
+     * @return array<string, Type>
+     */
+    public function visibleProperties(): array
+    {
+        $properties = array_merge($this->attributes, $this->relations);
+
+        if ($this->visible !== []) {
+            return array_intersect_key($properties, array_flip($this->visible));
+        }
+
+        if ($this->hidden !== []) {
+            return array_diff_key($properties, array_flip($this->hidden));
+        }
+
+        return $properties;
     }
 }

--- a/tests/Feature/ModelsTest.php
+++ b/tests/Feature/ModelsTest.php
@@ -4,6 +4,7 @@ use App\Models\ApiResponse;
 use App\Models\Comment;
 use App\Models\Post;
 use App\Models\User;
+use App\Models\Visibility;
 use Laravel\Ranger\Collectors\Models;
 use Laravel\Ranger\Components\Model;
 use Laravel\Surveyor\Types\ArrayType;
@@ -155,6 +156,60 @@ describe('eager loading', function () {
 
         expect($relations)->toHaveKey('authoredBy');
         expect($relations['authoredBy']->required)->toBeTrue();
+    });
+});
+
+describe('serialization visibility', function () {
+    it('captures the $hidden list from the model', function () {
+        $models = $this->collector->collect();
+        $userModel = $models->first(fn (Model $m) => $m->name === User::class);
+
+        expect($userModel->getHidden())->toBe(['password', 'remember_token']);
+    });
+
+    it('captures the $visible list from the model', function () {
+        $models = $this->collector->collect();
+        $visibility = $models->first(fn (Model $m) => $m->name === Visibility::class);
+
+        expect($visibility->getVisible())->toBe(['id', 'name', 'display_name']);
+    });
+
+    it('captures the $appends list from the model', function () {
+        $models = $this->collector->collect();
+        $visibility = $models->first(fn (Model $m) => $m->name === Visibility::class);
+
+        expect($visibility->getAppends())->toBe(['display_name']);
+    });
+
+    it('defaults visibility lists to empty arrays when undefined', function () {
+        $models = $this->collector->collect();
+        $postModel = $models->first(fn (Model $m) => $m->name === Post::class);
+
+        expect($postModel->getHidden())->toBe([]);
+        expect($postModel->getVisible())->toBe([]);
+        expect($postModel->getAppends())->toBe([]);
+    });
+
+    it('filters $hidden attributes out of visibleProperties()', function () {
+        $models = $this->collector->collect();
+        $userModel = $models->first(fn (Model $m) => $m->name === User::class);
+
+        $visible = $userModel->visibleProperties();
+
+        expect($visible)->not->toHaveKey('password');
+        expect($visible)->not->toHaveKey('remember_token');
+        expect($visible)->toHaveKey('email');
+    });
+
+    it('treats $visible as a whitelist in visibleProperties()', function () {
+        $models = $this->collector->collect();
+        $visibility = $models->first(fn (Model $m) => $m->name === Visibility::class);
+
+        $visible = $visibility->visibleProperties();
+
+        expect(array_keys($visible))->toEqualCanonicalizing(['id', 'name', 'display_name']);
+        expect($visible)->not->toHaveKey('secret');
+        expect($visible)->not->toHaveKey('internal_note');
     });
 });
 

--- a/workbench/app/Models/Visibility.php
+++ b/workbench/app/Models/Visibility.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $secret
+ * @property string $internal_note
+ * @property string $display_name
+ */
+class Visibility extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $visible = [
+        'id',
+        'name',
+        'display_name',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $appends = [
+        'display_name',
+    ];
+}


### PR DESCRIPTION
Surfaces the three Eloquent serialization-control properties on the Model component and adds a visibleProperties() helper that applies them: $visible acts as a whitelist when set, otherwise $hidden filters the keys out. Operates over merged attributes + relations since Eloquent's $hidden/$visible apply to relationships as well as columns.

Values are read via reflection on the model's default properties because a docblock @var (which the Laravel skeleton ships on $hidden) causes Surveyor to keep the typed array shape and discard the literal items. The existing $with extraction is moved to the same approach so it isn't silently broken by the same docblock pattern.

Closes laravel/wayfinder#135
