### PR TITLE
update `ClassResult` to `ClassLikeResult`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/routing": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/pint": "^1.22",
-        "laravel/surveyor": "^0.2.1",
+        "laravel/surveyor": "dev-template-bindings-via-static-method-dispatch-on-model-subclasses as 0.2.x-dev",
         "nikic/php-parser": "^5.4",
         "phpstan/phpdoc-parser": "^2.1",
         "spatie/php-structure-discoverer": "^2.3"
@@ -63,5 +63,11 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/levikl/surveyor"
+        }
+    ]
 }

--- a/src/Collectors/BroadcastEvents.php
+++ b/src/Collectors/BroadcastEvents.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\BroadcastEvent;
-use Laravel\Surveyor\Analyzed\ClassResult;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\Type;
@@ -56,7 +56,7 @@ class BroadcastEvents extends Collector
     /**
      * @param  class-string<ShouldBroadcast>  $class
      */
-    protected function resolveEventName(ClassResult $analyzed, string $class): string
+    protected function resolveEventName(ClassLikeResult $analyzed, string $class): string
     {
         if ($analyzed->hasMethod('broadcastAs')) {
             return $analyzed->getMethod('broadcastAs')->returnType()->value;
@@ -65,7 +65,7 @@ class BroadcastEvents extends Collector
         return $class;
     }
 
-    protected function resolveBroadcastWith(ClassResult $analyzed): Type
+    protected function resolveBroadcastWith(ClassLikeResult $analyzed): Type
     {
         if ($analyzed->hasMethod('broadcastWith')) {
             return $analyzed->getMethod('broadcastWith')->returnType();

--- a/src/Collectors/Models.php
+++ b/src/Collectors/Models.php
@@ -16,7 +16,7 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ranger\Components\Model as ModelComponent;
-use Laravel\Surveyor\Analyzed\ClassResult;
+use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\BoolType;
@@ -122,7 +122,7 @@ class Models extends Collector
         return array_values(array_filter($defaults[$propertyName], 'is_string'));
     }
 
-    protected function shouldSnakeCase(ClassResult $result): bool
+    protected function shouldSnakeCase(ClassLikeResult $result): bool
     {
         $propertyName = 'snakeAttributes';
 


### PR DESCRIPTION
@joetannenbaum recently updated surveyor's `ClassResult` to `ClassLikeResult` in order to also handle interfaces; as such, this change replaces all ranger usages of `ClassResult` with `ClassLikeResult`

this change is needed downstream in https://github.com/laravel/wayfinder/pull/249; this change should merge before that should merge

this should probably wait to merge until `ClassLikeResult` makes it into a stable release of `surveyor`, right now its only available via `dev-main` (this PR points to my in-flight surveyor branch instead of `dev-main` for dependency resolution reasons in https://github.com/laravel/wayfinder/pull/249, in either case the stable release caveat still applies)