### PR TITLE
Recursively resolve Arrayable props inside Inertia component data

### DIFF
--- a/src/Collectors/InertiaComponents.php
+++ b/src/Collectors/InertiaComponents.php
@@ -56,6 +56,9 @@ class InertiaComponents
 
     protected static function mergeComponentData(string $component, array $existingData, ArrayType $data): array
     {
+        $resolver = app(ArrayableResolver::class);
+        $data = self::normalizeData($data, $resolver);
+
         if (! self::hasComponent($component)) {
             return $data->value;
         }
@@ -68,20 +71,7 @@ class InertiaComponents
             }
         }
 
-        $resolver = app(ArrayableResolver::class);
-
         foreach ($data->value as $key => $value) {
-            if ($value instanceof VariableState) {
-                $value = $value->type();
-            }
-
-            if (
-                $value instanceof ClassType
-                && $resolved = $resolver->resolve($value)
-            ) {
-                $value = $resolved;
-            }
-
             if (in_array($key, $same)) {
                 if (get_class($value) !== get_class($existingData[$key])) {
                     $value1 = $value instanceof UnionType ? $value->types : [$value];
@@ -109,5 +99,55 @@ class InertiaComponents
         }
 
         return $existingData;
+    }
+
+    protected static function normalizeData(ArrayType $data, ArrayableResolver $resolver): ArrayType
+    {
+        $normalized = [];
+
+        foreach ($data->value as $key => $value) {
+            $normalized[$key] = self::normalizeValue($value, $resolver);
+        }
+
+        return (new ArrayType($normalized))
+            ->optional($data->isOptional())
+            ->nullable($data->isNullable());
+    }
+
+    protected static function normalizeValue(TypeContract|VariableState $value, ArrayableResolver $resolver): TypeContract
+    {
+        if ($value instanceof VariableState) {
+            $value = $value->type();
+        }
+
+        if ($value instanceof ClassType && $resolved = $resolver->resolve($value)) {
+            return $resolved
+                ->optional($value->isOptional())
+                ->nullable($value->isNullable());
+        }
+
+        if ($value instanceof ArrayType) {
+            return self::normalizeData($value, $resolver);
+        }
+
+        if ($value instanceof ArrayShapeType) {
+            return (new ArrayShapeType(
+                self::normalizeValue($value->keyType, $resolver),
+                self::normalizeValue($value->valueType, $resolver),
+            ))
+                ->optional($value->isOptional())
+                ->nullable($value->isNullable());
+        }
+
+        if ($value instanceof UnionType) {
+            return Type::union(...array_map(
+                fn ($type) => self::normalizeValue($type, $resolver),
+                $value->types,
+            ))
+                ->optional($value->isOptional())
+                ->nullable($value->isNullable());
+        }
+
+        return $value;
     }
 }

--- a/tests/Unit/InertiaComponentsTest.php
+++ b/tests/Unit/InertiaComponentsTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use App\Support\CheckoutSummary;
 use Laravel\Ranger\Collectors\InertiaComponents;
 use Laravel\Ranger\Components\InertiaResponse;
 use Laravel\Surveyor\Types\ArrayShapeType;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\BoolType;
+use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\IntType;
 use Laravel\Surveyor\Types\StringType;
 use Laravel\Surveyor\Types\Type;
@@ -29,6 +31,33 @@ describe('InertiaComponents static class', function () {
         expect($component->data)->toHaveKey('title');
         expect($component->data['title'])->toBeInstanceOf(StringType::class);
         expect($component->data['title']->isOptional())->toBeFalse();
+    });
+
+    it('resolves arrayable class props on first add', function () {
+        $data = new ArrayType(['summary' => new ClassType(CheckoutSummary::class)]);
+
+        InertiaComponents::addComponent('Checkout', $data);
+
+        $component = InertiaComponents::getComponent('Checkout');
+
+        expect($component->data['summary'])->toBeInstanceOf(ArrayType::class);
+        expect($component->data['summary']->value['total'])->toBeInstanceOf(IntType::class);
+        expect($component->data['summary']->value['currency'])->toBeInstanceOf(StringType::class);
+    });
+
+    it('resolves arrayable classes inside array shape props', function () {
+        $data = new ArrayType([
+            'summaries' => new ArrayShapeType(Type::int(), new ClassType(CheckoutSummary::class)),
+        ]);
+
+        InertiaComponents::addComponent('Checkout', $data);
+
+        $component = InertiaComponents::getComponent('Checkout');
+
+        expect($component->data['summaries'])->toBeInstanceOf(ArrayShapeType::class);
+        expect($component->data['summaries']->valueType)->toBeInstanceOf(ArrayType::class);
+        expect($component->data['summaries']->valueType->value['total'])->toBeInstanceOf(IntType::class);
+        expect($component->data['summaries']->valueType->value['currency'])->toBeInstanceOf(StringType::class);
     });
 
     it('returns empty data for non-existent components', function () {


### PR DESCRIPTION
## Summary

Normalize Inertia prop data before merge so that `Arrayable` / `JsonSerializable` classes are resolved to their array shape:

1. On the **first** add of a component (previously, normalization only ran during merge with existing data — a single-route component left `ClassType` unresolved).
2. **Inside** nested `ArrayType`, `ArrayShapeType`, and `UnionType` values, not just at the top level (previously, `Collection<Option>` produced `Array<unknown>` because the inner `Option` class was never walked).

## Motivation

`ArrayableResolver` in Surveyor already lifts a DTO's `toArray()` shape into the prop type — but only when the class sat directly under a key being merged against an existing component. A typed DTO pattern like:

```php
'options' => Option::collect($rows), // returns Collection<int, Option>
```

…still emitted `unknown` because:

- the `Option` class sat inside an `ArrayShapeType`'s `valueType`, and
- the merge-only resolution skipped components added for the first time.

This PR pairs with laravel/surveyor#41 to give users a way to get precise TypeScript types out of common controller patterns through Wayfinder.

## Changes

- `src/Collectors/InertiaComponents.php` — extract normalization into `normalizeData()` / `normalizeValue()` helpers that:
  - run before the `hasComponent` short-circuit (so first adds are normalized too),
  - recurse into `ArrayType`, `ArrayShapeType` (both `keyType` and `valueType`), and `UnionType`,
  - preserve `optional` / `nullable` flags on the original wrapper.
- `tests/Unit/InertiaComponentsTest.php` — two new tests using the existing `App\Support\CheckoutSummary` workbench fixture:
  - resolves an Arrayable class prop on first add,
  - resolves an Arrayable class nested inside an `ArrayShapeType`.

## Test plan

- [x] `./vendor/bin/pest tests/Unit/InertiaComponentsTest.php`
- [x] `./vendor/bin/pint src/Collectors/InertiaComponents.php tests/Unit/InertiaComponentsTest.php`
- [x] Existing merge / union / nested-shape tests still pass.

## Notes

- No Wayfinder change is required; it consumes the resolved `InertiaResponse` and emits the improved TypeScript automatically.
- Cross-linked to laravel/surveyor#41 (inline `@var` override), which is the complementary escape hatch when even DTO patterns aren't usable.