### PR TITLE
Count a single rule parameter as having parameters

### DIFF
--- a/src/Validation/Rule.php
+++ b/src/Validation/Rule.php
@@ -34,6 +34,6 @@ class Rule
 
     public function hasParams(): bool
     {
-        return count($this->getParams()) > 1;
+        return $this->getParams() !== [];
     }
 }

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -44,9 +44,11 @@ describe('Rule class', function () {
 
     it('detects when rule has parameters', function () {
         $ruleWithParams = new Rule(['max', ['value' => 255, 'other' => true]]);
-        $ruleWithoutParams = new Rule(['required', ['only' => 'one']]);
+        $ruleWithOneParam = new Rule(['array', ['only' => 'one']]);
+        $ruleWithoutParams = new Rule(['required', []]);
 
         expect($ruleWithParams->hasParams())->toBeTrue();
+        expect($ruleWithOneParam->hasParams())->toBeTrue();
         expect($ruleWithoutParams->hasParams())->toBeFalse();
     });
 });


### PR DESCRIPTION
`Rule::hasParams()` only returned true when a rule had more than one parameter, so a rule like `array:only` looked like it had none. Consumers then fall back to a generic type and lose the parameter. Any non-empty parameter list now counts.
