### PR TITLE
Stop stripping quotes from URL default values

### DIFF
--- a/src/Collectors/Routes.php
+++ b/src/Collectors/Routes.php
@@ -126,6 +126,24 @@ class Routes extends Collector
         return $this->urlDefaults[$middleware] ??= $this->getDefaultsFromClassMethod($middleware, 'handle');
     }
 
+    /**
+     * Unwrap a quoted token, leaving quotes that belong to the value itself in place.
+     */
+    protected function tokenValue(string $token): string
+    {
+        $quote = $token[0] ?? '';
+
+        if (strlen($token) < 2 || ! in_array($quote, ["'", '"']) || ! str_ends_with($token, $quote)) {
+            return $token;
+        }
+
+        $contents = substr($token, 1, -1);
+
+        return $quote === "'"
+            ? preg_replace('/\\\\([\\\\\'])/', '$1', $contents)
+            : stripcslashes($contents);
+    }
+
     protected function getDefaultsFromClassMethod(string $class, string $method)
     {
         if (! class_exists($class)) {
@@ -204,15 +222,18 @@ class Routes extends Collector
                     $valueToken = $tokens[$index + $count];
                 }
 
-                $value = trim($valueToken[1], "'\"");
+                $isString = is_array($valueToken) && $valueToken[0] === T_CONSTANT_ENCAPSED_STRING;
+                $value = $this->tokenValue($valueToken[1]);
 
-                $value = match ($value) {
-                    'true' => 1,
-                    'false' => 0,
-                    default => $value,
-                };
+                if (! $isString) {
+                    $value = match ($value) {
+                        'true' => 1,
+                        'false' => 0,
+                        default => $value,
+                    };
+                }
 
-                $defaults[trim($previousToken[1], "'\"")] = $value;
+                $defaults[$this->tokenValue($previousToken[1])] = $value;
             }
 
             // Check for the closing bracket of the array

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -167,6 +167,19 @@ describe('URL defaults from middleware', function () {
         expect($localeParam->default)->toBe('en');
     });
 
+    it('keeps quotes that are part of the default value', function () {
+        $quotedRoute = $this->routes->first(fn (Route $r) => str_contains($r->uri(), 'with-quoted-defaults'));
+        $params = $quotedRoute->parameters();
+
+        $defaults = $params->mapWithKeys(fn (RouteParameter $p) => [$p->name => $p->default]);
+
+        expect($defaults['doubleQuoted'])->toBe('say "hi"');
+        expect($defaults['singleQuoted'])->toBe("it's here");
+        expect($defaults['escaped'])->toBe('it\'s "quoted"');
+        expect($defaults['flag'])->toBe('1');
+        expect($defaults['word'])->toBe('true');
+    });
+
     it('handles mixed defaults and non-defaults', function () {
         $mixedRoute = $this->routes->first(fn (Route $r) => str_contains($r->uri(), 'also'));
         $params = $mixedRoute->parameters();

--- a/workbench/app/Http/Controllers/UrlDefaultsController.php
+++ b/workbench/app/Http/Controllers/UrlDefaultsController.php
@@ -13,4 +13,9 @@ class UrlDefaultsController
     {
         //
     }
+
+    public function quotedDefaults()
+    {
+        //
+    }
 }

--- a/workbench/app/Http/Middleware/QuotedUrlDefaultsMiddleware.php
+++ b/workbench/app/Http/Middleware/QuotedUrlDefaultsMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Support\Facades\URL;
+
+class QuotedUrlDefaultsMiddleware
+{
+    public function handle($request, $next)
+    {
+        URL::defaults([
+            'doubleQuoted' => 'say "hi"',
+            'singleQuoted' => "it's here",
+            'escaped' => "it's \"quoted\"",
+            'flag' => true,
+            'word' => 'true',
+        ]);
+
+        return $next($request);
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\ResourceController;
 use App\Http\Controllers\TwoRoutesSameActionController;
 use App\Http\Controllers\UrlDefaultsController;
+use App\Http\Middleware\QuotedUrlDefaultsMiddleware;
 use App\Http\Middleware\UrlDefaultsMiddleware;
 use Illuminate\Support\Facades\Route;
 
@@ -51,6 +52,7 @@ Route::get('/audit-entries/{audit_entry}', [AuditEntryController::class, 'show']
 
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}', [UrlDefaultsController::class, 'onlyDefaults']);
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}/also/{timezone}', [UrlDefaultsController::class, 'mixedDefaults']);
+Route::middleware(QuotedUrlDefaultsMiddleware::class)->post('/with-quoted-defaults/{doubleQuoted}/{singleQuoted}/{escaped}/{flag}/{word}', [UrlDefaultsController::class, 'quotedDefaults']);
 
 Route::get('/keys/{key}', [KeyController::class, 'show']);
 Route::get('/keys/{key:uuid}/edit', [KeyController::class, 'edit']);


### PR DESCRIPTION
`URL::defaults(['title' => 'say "hi"'])` came back as `say "hi`. The value token was unwrapped with `trim($token, "'\"")`, which strips quote characters from both ends of the value rather than just the delimiters. Tokens are now unwrapped properly, applying the escape rules for whichever quote style was used, and keys get the same treatment.

One related change: `true` and `false` still become 1 and 0, but only when written as keywords. A quoted `'true'` now stays the string it was instead of collapsing to 1.
