### PR TITLE
Stop rescanning the application for every collector

### DIFF
--- a/src/Collectors/BroadcastEvents.php
+++ b/src/Collectors/BroadcastEvents.php
@@ -10,8 +10,6 @@ use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\Contracts\Type;
-use Spatie\StructureDiscoverer\Discover;
-use Spatie\StructureDiscoverer\Support\Conditions\ConditionBuilder;
 
 class BroadcastEvents extends Collector
 {
@@ -25,12 +23,7 @@ class BroadcastEvents extends Collector
      */
     public function collect(): Collection
     {
-        $discovered = Discover::in(...$this->appPaths)
-            ->any(
-                ConditionBuilder::create()->classes()->implementing(ShouldBroadcast::class),
-                ConditionBuilder::create()->classes()->implementing(ShouldBroadcastNow::class),
-            )
-            ->get();
+        $discovered = $this->inventory()->classesImplementing(ShouldBroadcast::class, ShouldBroadcastNow::class);
 
         return collect($discovered)
             ->filter()

--- a/src/Collectors/Collector.php
+++ b/src/Collectors/Collector.php
@@ -4,6 +4,7 @@ namespace Laravel\Ranger\Collectors;
 
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Support\HasPaths;
+use Laravel\Ranger\Support\Inventory;
 
 abstract class Collector
 {
@@ -32,6 +33,11 @@ abstract class Collector
     public function getCollection(): Collection
     {
         return $this->cached ??= $this->collect();
+    }
+
+    protected function inventory(): Inventory
+    {
+        return Inventory::in(...$this->appPaths);
     }
 
     abstract public function collect(): Collection;

--- a/src/Collectors/Enums.php
+++ b/src/Collectors/Enums.php
@@ -6,7 +6,6 @@ use BackedEnum;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\Enum as EnumComponent;
 use ReflectionClass;
-use Spatie\StructureDiscoverer\Discover;
 
 class Enums extends Collector
 {
@@ -15,7 +14,7 @@ class Enums extends Collector
      */
     public function collect(): Collection
     {
-        return collect(Discover::in(...$this->appPaths)->enums()->get())
+        return collect($this->inventory()->enums())
             ->map($this->toComponent(...));
     }
 

--- a/src/Collectors/InertiaSharedData.php
+++ b/src/Collectors/InertiaSharedData.php
@@ -10,7 +10,6 @@ use Laravel\Surveyor\Types\ArrayType;
 use Laravel\Surveyor\Types\BoolType;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Surveyor\Types\UnionType;
-use Spatie\StructureDiscoverer\Discover;
 
 class InertiaSharedData extends Collector
 {
@@ -24,10 +23,7 @@ class InertiaSharedData extends Collector
      */
     public function collect(): Collection
     {
-        $discovered = Discover::in(...$this->appPaths)
-            ->classes()
-            ->extending('Inertia\\Middleware')
-            ->get();
+        $discovered = $this->inventory()->classesExtending('Inertia\\Middleware');
 
         return collect($discovered)->map($this->processSharedData(...));
     }

--- a/src/Collectors/Models.php
+++ b/src/Collectors/Models.php
@@ -24,7 +24,6 @@ use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Contracts\Type as SurveyorTypeContract;
 use Laravel\Surveyor\Types\Type;
 use ReflectionClass;
-use Spatie\StructureDiscoverer\Discover;
 use Throwable;
 
 class Models extends Collector
@@ -41,10 +40,7 @@ class Models extends Collector
      */
     public function collect(): Collection
     {
-        $discovered = Discover::in(...$this->appPaths)
-            ->classes()
-            ->extending(Model::class, User::class, Pivot::class)
-            ->get();
+        $discovered = $this->inventory()->classesExtending(Model::class, User::class, Pivot::class);
 
         foreach ($discovered as $model) {
             $this->toComponent($model);

--- a/src/Collectors/Routes.php
+++ b/src/Collectors/Routes.php
@@ -13,7 +13,6 @@ use Laravel\Ranger\Components\Route;
 use Laravel\Ranger\Support\Config;
 use ReflectionClass;
 use ReflectionProperty;
-use Spatie\StructureDiscoverer\Discover;
 
 class Routes extends Collector
 {
@@ -56,10 +55,7 @@ class Routes extends Collector
 
     protected function collectProviderUrlDefaults(): void
     {
-        $discovered = Discover::in(...$this->appPaths)
-            ->classes()
-            ->extending(ServiceProvider::class)
-            ->get();
+        $discovered = $this->inventory()->classesExtending(ServiceProvider::class);
 
         foreach ($discovered as $class) {
             $this->universalUrlDefaults = array_merge(

--- a/src/Support/Inventory.php
+++ b/src/Support/Inventory.php
@@ -2,13 +2,29 @@
 
 namespace Laravel\Ranger\Support;
 
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use Spatie\StructureDiscoverer\Data\DiscoveredStructure;
-use Spatie\StructureDiscoverer\Discover;
 use Spatie\StructureDiscoverer\Support\Conditions\ConditionBuilder;
 use Spatie\StructureDiscoverer\Support\Conditions\HasConditions;
+use Spatie\StructureDiscoverer\Support\StructureChainResolver;
+use Spatie\StructureDiscoverer\TokenParsers\FileTokenParser;
+use SplFileInfo;
+use Throwable;
 
 class Inventory
 {
+    protected const VERSION = 1;
+
+    protected const HASH = 'xxh128';
+
+    /**
+     * Prefixes the index files. The cache directory is likely to be shared
+     * with Surveyor's, so clearing ours must not reach its entries.
+     */
+    protected const PREFIX = 'inventory-';
+
     /**
      * Structures found in a set of paths, keyed by those paths.
      *
@@ -27,7 +43,8 @@ class Inventory
     }
 
     /**
-     * Drop the scanned structures, so the next question re-reads from disk.
+     * Forget what was read this run, so the next question goes back to the
+     * files. What is on disk is left alone.
      */
     public static function flush(): void
     {
@@ -35,13 +52,29 @@ class Inventory
     }
 
     /**
+     * Throw away everything that was read, on disk as well as in memory.
+     */
+    public static function clear(): void
+    {
+        static::flush();
+
+        $directory = Config::get('cache.directory');
+
+        if ($directory === null || ! is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory.'/'.self::PREFIX.'*.cache') ?: [] as $file) {
+            unlink($file);
+        }
+    }
+
+    /**
      * @return array<DiscoveredStructure>
      */
     public function structures(): array
     {
-        return static::$scans[implode('|', $this->paths)] ??= Discover::in(...$this->paths)
-            ->full()
-            ->get();
+        return static::$scans[implode('|', $this->paths)] ??= $this->read();
     }
 
     /**
@@ -87,5 +120,183 @@ class Inventory
         }
 
         return $found;
+    }
+
+    /**
+     * @return array<DiscoveredStructure>
+     */
+    protected function read(): array
+    {
+        [$stamps, $mtimes] = $this->stampFiles();
+        [$cached, $writtenAt] = $this->load();
+
+        $records = [];
+        $changed = count($cached) !== count($stamps);
+
+        $parser = new FileTokenParser;
+
+        foreach ($stamps as $file => $stamp) {
+            $record = $cached[$file] ?? null;
+
+            if ($record !== null && $record['stamp'] === $stamp && ! $this->racy($mtimes[$file], $writtenAt, $file, $record)) {
+                $records[$file] = $record;
+
+                continue;
+            }
+
+            $records[$file] = $this->record($parser, $stamp, $file);
+            $changed = true;
+        }
+
+        // Written before the chains are resolved, because a chain is a fact
+        // about the whole set rather than about one file, and a cached record
+        // carrying one would stop the next run from working it out again.
+        if ($changed) {
+            $this->save($records);
+        }
+
+        $structures = [];
+
+        foreach ($records as $record) {
+            foreach ($record['structures'] as $fqcn => $structure) {
+                $structures[$fqcn] = $structure;
+            }
+        }
+
+        (new StructureChainResolver)->execute($structures);
+
+        return array_values($structures);
+    }
+
+    /**
+     * @return array{stamp: string, hash: string, structures: array<string, DiscoveredStructure>}
+     */
+    protected function record(FileTokenParser $parser, string $stamp, string $file): array
+    {
+        $contents = file_get_contents($file) ?: '';
+
+        try {
+            $structures = $parser->execute($file, $contents);
+        } catch (Throwable) {
+            // A file that cannot be parsed holds nothing we can act on, and
+            // failing the whole run over one of them is worse than skipping it.
+            $structures = [];
+        }
+
+        return ['stamp' => $stamp, 'hash' => hash(self::HASH, $contents), 'structures' => $structures];
+    }
+
+    /**
+     * Whether a file could have changed without its stamp changing.
+     *
+     * A stamp is the modification time and size, and modification time only
+     * has a second of resolution, so a file written in the same second the
+     * index was, at the same length, still looks untouched. Renaming a parent
+     * class to another of the same length does exactly that, and a watcher
+     * runs within the same second as the save that woke it. Files that old or
+     * older cannot be in that window, so only the recent ones are read.
+     *
+     * @param  array{stamp: string, hash: string, structures: array<string, DiscoveredStructure>}  $record
+     */
+    protected function racy(int $mtime, ?int $writtenAt, string $file, array $record): bool
+    {
+        if ($writtenAt === null || $mtime < $writtenAt) {
+            return false;
+        }
+
+        return hash(self::HASH, file_get_contents($file) ?: '') !== ($record['hash'] ?? null);
+    }
+
+    /**
+     * Modification time and size of every PHP file in the paths, which is what
+     * decides whether a file has to be read again. Hashing every file instead
+     * would be sturdier but means reading all of them on every run, so only
+     * the files recent enough to be ambiguous get hashed. See racy().
+     *
+     * @return array{0: array<string, string>, 1: array<string, int>}
+     */
+    protected function stampFiles(): array
+    {
+        $stamps = [];
+        $mtimes = [];
+
+        foreach ($this->paths as $path) {
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            $files = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            );
+
+            /** @var SplFileInfo $file */
+            foreach ($files as $file) {
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $mtimes[$file->getPathname()] = $mtime = $file->getMTime();
+                $stamps[$file->getPathname()] = $mtime.':'.$file->getSize();
+            }
+        }
+
+        return [$stamps, $mtimes];
+    }
+
+    /**
+     * @return array{0: array<string, array{stamp: string, hash: string, structures: array<string, DiscoveredStructure>}>, 1: int|null}
+     */
+    protected function load(): array
+    {
+        $file = $this->cacheFile();
+
+        if ($file === null || ! is_file($file)) {
+            return [[], null];
+        }
+
+        try {
+            $index = unserialize(file_get_contents($file) ?: '');
+        } catch (Throwable) {
+            return [[], null];
+        }
+
+        if (! is_array($index) || ($index['version'] ?? null) !== self::VERSION) {
+            return [[], null];
+        }
+
+        return [$index['files'] ?? [], $index['written_at'] ?? null];
+    }
+
+    /**
+     * @param  array<string, array{stamp: string, hash: string, structures: array<string, DiscoveredStructure>}>  $records
+     */
+    protected function save(array $records): void
+    {
+        $file = $this->cacheFile();
+
+        if ($file === null) {
+            return;
+        }
+
+        if (! is_dir($directory = dirname($file))) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($file, serialize([
+            'version' => self::VERSION,
+            'written_at' => time(),
+            'files' => $records,
+        ]));
+    }
+
+    protected function cacheFile(): ?string
+    {
+        $directory = Config::get('cache.directory');
+
+        if ($directory === null) {
+            return null;
+        }
+
+        return $directory.'/'.self::PREFIX.md5(implode('|', $this->paths)).'.cache';
     }
 }

--- a/src/Support/Inventory.php
+++ b/src/Support/Inventory.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Laravel\Ranger\Support;
+
+use Spatie\StructureDiscoverer\Data\DiscoveredStructure;
+use Spatie\StructureDiscoverer\Discover;
+use Spatie\StructureDiscoverer\Support\Conditions\ConditionBuilder;
+use Spatie\StructureDiscoverer\Support\Conditions\HasConditions;
+
+class Inventory
+{
+    /**
+     * Structures found in a set of paths, keyed by those paths.
+     *
+     * @var array<string, array<DiscoveredStructure>>
+     */
+    protected static array $scans = [];
+
+    /**
+     * @param  list<string>  $paths
+     */
+    public function __construct(protected array $paths) {}
+
+    public static function in(string ...$paths): self
+    {
+        return new self($paths);
+    }
+
+    /**
+     * Drop the scanned structures, so the next question re-reads from disk.
+     */
+    public static function flush(): void
+    {
+        static::$scans = [];
+    }
+
+    /**
+     * @return array<DiscoveredStructure>
+     */
+    public function structures(): array
+    {
+        return static::$scans[implode('|', $this->paths)] ??= Discover::in(...$this->paths)
+            ->full()
+            ->get();
+    }
+
+    /**
+     * Classes extending any of the given parents, however far up the chain.
+     *
+     * @return list<class-string>
+     */
+    public function classesExtending(string ...$parents): array
+    {
+        return $this->match(ConditionBuilder::create()->classes()->extending(...$parents));
+    }
+
+    /**
+     * Classes implementing any of the given interfaces, however far up the chain.
+     *
+     * @return list<class-string>
+     */
+    public function classesImplementing(string ...$interfaces): array
+    {
+        return $this->match(ConditionBuilder::create()->classes()->implementing(...$interfaces));
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public function enums(): array
+    {
+        return $this->match(ConditionBuilder::create()->enums());
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    protected function match(HasConditions $conditions): array
+    {
+        $store = $conditions->conditionsStore();
+        $found = [];
+
+        foreach ($this->structures() as $structure) {
+            if ($store->satisfies($structure)) {
+                $found[] = $structure->getFcqn();
+            }
+        }
+
+        return $found;
+    }
+}

--- a/tests/Unit/InventoryCacheTest.php
+++ b/tests/Unit/InventoryCacheTest.php
@@ -1,0 +1,197 @@
+<?php
+
+use Laravel\Ranger\Support\Config;
+use Laravel\Ranger\Support\Inventory;
+
+beforeEach(function () {
+    $this->source = sys_get_temp_dir().'/ranger-inventory-src-'.getmypid();
+    $this->cache = sys_get_temp_dir().'/ranger-inventory-cache-'.getmypid();
+
+    foreach ([$this->source, $this->cache] as $directory) {
+        if (is_dir($directory)) {
+            array_map('unlink', glob($directory.'/*') ?: []);
+        } else {
+            mkdir($directory, 0755, true);
+        }
+    }
+
+    Config::set('cache.directory', $this->cache);
+    Inventory::flush();
+
+    $this->write = function (string $name, string $body) {
+        file_put_contents($this->source."/{$name}.php", "<?php namespace Fixture; {$body}");
+    };
+
+    $this->read = function () {
+        Inventory::flush();
+
+        return array_map(
+            fn ($structure) => $structure->getFcqn(),
+            Inventory::in($this->source)->structures(),
+        );
+    };
+});
+
+afterEach(function () {
+    Config::set('cache.directory', null);
+
+    foreach ([$this->source, $this->cache] as $directory) {
+        array_map('unlink', glob($directory.'/*') ?: []);
+        @rmdir($directory);
+    }
+});
+
+it('writes an index it can read back', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+    expect(glob($this->cache.'/inventory-*.cache'))->toHaveCount(1);
+
+    // Second read comes from the index rather than the files.
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+});
+
+it('re-reads a file that changed', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+
+    ($this->write)('Alpha', 'class AlphaRenamed {}');
+
+    expect(($this->read)())->toBe(['Fixture\AlphaRenamed']);
+});
+
+it('drops files that were deleted', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    ($this->write)('Beta', 'class Beta {}');
+    expect(($this->read)())->toHaveCount(2);
+
+    unlink($this->source.'/Beta.php');
+
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+});
+
+it('picks up files that were added', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    expect(($this->read)())->toHaveCount(1);
+
+    ($this->write)('Beta', 'class Beta {}');
+
+    expect(($this->read)())->toHaveCount(2);
+});
+
+it('resolves chains across files that came from the index', function () {
+    ($this->write)('Base', 'class Base {}');
+    ($this->write)('Middle', 'class Middle extends Base {}');
+    ($this->write)('Leaf', 'class Leaf extends Middle {}');
+
+    // Prime the index, then read it back and check the chain still resolves.
+    ($this->read)();
+
+    expect(Inventory::in($this->source)->classesExtending('Fixture\Base'))
+        ->toContain('Fixture\Middle', 'Fixture\Leaf');
+});
+
+it('falls back to reading the files when the index is unreadable', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    ($this->read)();
+
+    file_put_contents(glob($this->cache.'/inventory-*.cache')[0], 'not a serialized index');
+
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+});
+
+it('ignores an index written by a different version', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    ($this->read)();
+
+    $file = glob($this->cache.'/inventory-*.cache')[0];
+    file_put_contents($file, serialize(['version' => -1, 'files' => ['bogus' => ['stamp' => 'x', 'structures' => []]]]));
+
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+});
+
+it('works without a cache directory and writes nothing', function () {
+    Config::set('cache.directory', null);
+
+    ($this->write)('Alpha', 'class Alpha {}');
+
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+    expect(glob($this->cache.'/inventory-*.cache'))->toBeEmpty();
+});
+
+// Modification time has a second of resolution, so a file rewritten in the
+// same second the index was, at the same length, still looks untouched.
+// Renaming a parent class to another of the same length does exactly that.
+it('notices a same-second change that keeps the file length', function () {
+    ($this->write)('Base', 'class Base {}');
+    ($this->write)('Other', 'class Othr {}');
+    ($this->write)('Leaf', 'class Leaf extends Base {}');
+
+    expect(Inventory::in($this->source)->classesExtending('Fixture\Base'))->toBe(['Fixture\Leaf']);
+
+    $leaf = $this->source.'/Leaf.php';
+    $before = filemtime($leaf);
+
+    // Same length as the original, so only the contents differ.
+    ($this->write)('Leaf', 'class Leaf extends Othr {}');
+    touch($leaf, $before);
+
+    expect(filemtime($leaf))->toBe($before);
+
+    Inventory::flush();
+
+    expect(Inventory::in($this->source)->classesExtending('Fixture\Base'))->toBe([]);
+    expect(Inventory::in($this->source)->classesExtending('Fixture\Othr'))->toBe(['Fixture\Leaf']);
+});
+
+it('does not re-read files older than the index', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    ($this->read)();
+
+    // Backdate the file so it sits clearly before the index was written, then
+    // change it underneath without touching its stamp. A file that old cannot
+    // be in the racy window, so the index is trusted and the edit is missed —
+    // which is the trade that keeps a warm read down to a stat per file.
+    $file = $this->source.'/Alpha.php';
+    touch($file, time() - 3600);
+    ($this->read)();
+
+    $stamp = filemtime($file);
+    file_put_contents($file, '<?php namespace Fixture; class Alphb {}');
+    touch($file, $stamp);
+
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+});
+
+it('clears the index from disk', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    ($this->read)();
+
+    expect(glob($this->cache.'/inventory-*.cache'))->toHaveCount(1);
+
+    Inventory::clear();
+
+    expect(glob($this->cache.'/inventory-*.cache'))->toBeEmpty();
+    expect(($this->read)())->toBe(['Fixture\Alpha']);
+});
+
+// Wayfinder points Ranger and Surveyor at the same directory, so clearing one
+// must not take the other's entries with it.
+it('leaves cache entries that are not its own alone', function () {
+    ($this->write)('Alpha', 'class Alpha {}');
+    ($this->read)();
+
+    $foreign = $this->cache.'/'.md5('someone-else').'.cache';
+    file_put_contents($foreign, 'not ours');
+
+    Inventory::clear();
+
+    expect(glob($this->cache.'/inventory-*.cache'))->toBeEmpty();
+    expect(is_file($foreign))->toBeTrue();
+});
+
+it('can be cleared with no cache directory configured', function () {
+    Config::set('cache.directory', null);
+
+    Inventory::clear();
+})->throwsNoExceptions();

--- a/tests/Unit/InventoryTest.php
+++ b/tests/Unit/InventoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Enums\Status;
+use App\Enums\UserRole;
+use App\Events\PostUpdated;
+use App\Events\UserCreated;
+use App\Models\Post;
+use App\Models\User;
+use App\Providers\WorkbenchServiceProvider;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Ranger\Support\Inventory;
+
+beforeEach(function () {
+    Inventory::flush();
+
+    $this->inventory = Inventory::in($this->app->path());
+});
+
+it('finds classes extending a parent', function () {
+    expect($this->inventory->classesExtending(Model::class))
+        ->toContain(Post::class);
+});
+
+it('finds classes extending any of several parents', function () {
+    $found = $this->inventory->classesExtending(Model::class, Authenticatable::class, ServiceProvider::class);
+
+    expect($found)->toContain(Post::class, User::class, WorkbenchServiceProvider::class);
+});
+
+// A parent is only followed while it lives in the scanned paths. App\Models\User
+// extends Authenticatable, which lives in the framework, so the chain stops
+// there and asking for Model alone will not find it. This is why the model
+// collector names Model, Authenticatable and Pivot rather than Model alone.
+it('does not follow ancestry beyond the scanned paths', function () {
+    expect($this->inventory->classesExtending(Model::class))
+        ->not->toContain(User::class);
+
+    expect($this->inventory->classesExtending(Authenticatable::class))
+        ->toContain(User::class);
+});
+
+it('finds enums', function () {
+    expect($this->inventory->enums())
+        ->toHaveCount(4)
+        ->toContain(Status::class, UserRole::class);
+});
+
+it('finds classes implementing any of several interfaces', function () {
+    expect($this->inventory->classesImplementing(ShouldBroadcast::class, ShouldBroadcastNow::class))
+        ->toContain(UserCreated::class, PostUpdated::class);
+});
+
+it('does not return enums when asked for classes', function () {
+    expect($this->inventory->classesExtending(Model::class))
+        ->not->toContain(Status::class);
+});
+
+it('does not return classes when asked for enums', function () {
+    expect($this->inventory->enums())
+        ->not->toContain(User::class);
+});
+
+// Conditions used to accumulate on a shared builder, so the second question
+// asked was answered with the first question's conditions still attached and
+// every question after the first came back empty.
+it('answers each question independently of the ones before it', function () {
+    $isolated = [
+        'models' => Inventory::in($this->app->path())->classesExtending(Model::class),
+        'enums' => Inventory::in($this->app->path())->classesExtending(ServiceProvider::class),
+        'events' => Inventory::in($this->app->path())->classesImplementing(ShouldBroadcast::class),
+    ];
+
+    $sequential = [
+        'models' => $this->inventory->classesExtending(Model::class),
+        'enums' => $this->inventory->classesExtending(ServiceProvider::class),
+        'events' => $this->inventory->classesImplementing(ShouldBroadcast::class),
+    ];
+
+    expect($sequential['models'])->toEqual($isolated['models'])->not->toBeEmpty();
+    expect($sequential['enums'])->toEqual($isolated['enums'])->not->toBeEmpty();
+    expect($sequential['events'])->toEqual($isolated['events'])->not->toBeEmpty();
+});
+
+it('scans the same paths once and shares the result', function () {
+    $first = Inventory::in($this->app->path())->structures();
+    $second = Inventory::in($this->app->path())->structures();
+
+    expect($second)->toBe($first);
+    expect($second[array_key_first($second)])->toBe($first[array_key_first($first)]);
+});
+
+it('rescans after being flushed', function () {
+    $first = $this->inventory->structures();
+
+    Inventory::flush();
+
+    $second = Inventory::in($this->app->path())->structures();
+
+    expect($second)->not->toBe($first);
+    expect($second)->toHaveCount(count($first));
+});


### PR DESCRIPTION
Five collectors each asked Spatie's structure discoverer their own question, and each question read every PHP file in the app. On a large application that was five full scans per run, whether or not anything had changed.

There is now a single Inventory that owns the question of what classes live in a set of paths. The collectors ask it instead, so the files are read once and only the matching differs. What it reads is remembered per file, so a run only pays for the files that changed since the last one.

Keeping the index between runs is opt-in: nothing is written unless a cache directory is configured through Config, so this changes nothing for anyone who does not set one. Inventory::clear() removes it, and only ever touches its own entries, since the directory is likely shared with Surveyor's cache.
