### PR TITLE
Leave marked declarations out of collected components

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ $ranger->walk();
 | **Inertia Shared Data**   | Globally shared Inertia.js props                                                                               |
 | **Inertia Components**    | Inertia.js page components with their expected props                                                           |
 
+Each collector skips whatever carries an ignore marker. See [Ignore Markers](#ignore-markers).
+
+### Ignore Markers
+
+Every collector leaves out declarations an application has marked to be left out, so a consumer cannot pass on something the author held back. Ranger honors any attribute implementing `Laravel\Surveyor\Contracts\Ignored`, on a model, an enum or one of its cases, a broadcast event or channel, and a controller class or action, whose routes are dropped with it. A relation pointing at a marked model is dropped too, since no type is left to point at.
+
+Markers can carry a condition, which ranger resolves as a config key, a `[class, method]` callable, or a plain bool:
+
+```php
+#[Ignore(unless: 'services.fake_source_provider')]
+case GitFake = 'gitfake';
+```
+
+Conditions are resolved while collecting, not while analyzing, so a cached analysis is still answered for the environment collecting it.
+
 ## Contributing
 
 Thank you for considering contributing to Ranger! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/routing": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/pint": "^1.22",
-        "laravel/surveyor": "^0.2.0",
+        "laravel/surveyor": "^0.3.0",
         "nikic/php-parser": "^5.4",
         "phpstan/phpdoc-parser": "^2.1",
         "spatie/php-structure-discoverer": "^2.3"

--- a/src/Collectors/BroadcastChannels.php
+++ b/src/Collectors/BroadcastChannels.php
@@ -5,6 +5,7 @@ namespace Laravel\Ranger\Collectors;
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\BroadcastChannel;
+use Laravel\Ranger\Support\Ignores;
 
 class BroadcastChannels extends Collector
 {
@@ -19,6 +20,7 @@ class BroadcastChannels extends Collector
     public function collect(): Collection
     {
         return collect($this->broadcastManager->getChannels())
+            ->reject(fn ($channel) => is_string($channel) && Ignores::markedClass($channel))
             ->map(fn ($channel, $name) => new BroadcastChannel($name, $channel));
     }
 }

--- a/src/Collectors/BroadcastEvents.php
+++ b/src/Collectors/BroadcastEvents.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\BroadcastEvent;
+use Laravel\Ranger\Support\Ignores;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
@@ -34,15 +35,21 @@ class BroadcastEvents extends Collector
 
         return collect($discovered)
             ->filter()
-            ->map($this->toBroadcastEvent(...));
+            ->map($this->toBroadcastEvent(...))
+            ->filter()
+            ->values();
     }
 
     /**
      * @param  class-string<ShouldBroadcast>  $class
      */
-    protected function toBroadcastEvent(string $class): BroadcastEvent
+    protected function toBroadcastEvent(string $class): ?BroadcastEvent
     {
         $analyzed = $this->analyzer->analyzeClass($class)->result();
+
+        if ($analyzed->isIgnored() || Ignores::markedClass($class)) {
+            return null;
+        }
 
         $eventName = $this->resolveEventName($analyzed, $class);
         $broadcastWith = $this->resolveBroadcastWith($analyzed);

--- a/src/Collectors/Enums.php
+++ b/src/Collectors/Enums.php
@@ -5,7 +5,9 @@ namespace Laravel\Ranger\Collectors;
 use BackedEnum;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\Enum as EnumComponent;
-use ReflectionClass;
+use Laravel\Ranger\Support\Ignores;
+use ReflectionEnum;
+use ReflectionEnumBackedCase;
 use Spatie\StructureDiscoverer\Discover;
 
 class Enums extends Collector
@@ -16,20 +18,36 @@ class Enums extends Collector
     public function collect(): Collection
     {
         return collect(Discover::in(...$this->appPaths)->enums()->get())
-            ->map($this->toComponent(...));
+            ->map($this->toComponent(...))
+            ->filter()
+            ->values();
     }
 
     /**
      * @param  class-string<BackedEnum|\UnitEnum>  $enum
      */
-    protected function toComponent(string $enum): EnumComponent
+    protected function toComponent(string $enum): ?EnumComponent
     {
-        $cases = collect($enum::cases())
-            ->mapWithKeys(fn ($case, $index) => [$case->name => $case instanceof BackedEnum ? $case->value : (int) $index])
-            ->all();
+        $reflection = new ReflectionEnum($enum);
+
+        if (Ignores::marked($reflection)) {
+            return null;
+        }
+
+        $cases = [];
+
+        foreach ($reflection->getCases() as $index => $case) {
+            if (Ignores::marked($case)) {
+                continue;
+            }
+
+            $cases[$case->getName()] = $case instanceof ReflectionEnumBackedCase
+                ? $case->getBackingValue()
+                : $index;
+        }
 
         $component = new EnumComponent($enum, $cases);
-        $component->setFilePath((new ReflectionClass($enum))->getFileName());
+        $component->setFilePath($reflection->getFileName());
 
         return $component;
     }

--- a/src/Collectors/Models.php
+++ b/src/Collectors/Models.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ranger\Components\Model as ModelComponent;
+use Laravel\Ranger\Support\Ignores;
 use Laravel\Surveyor\Analyzed\ClassLikeResult;
 use Laravel\Surveyor\Analyzer\Analyzer;
 use Laravel\Surveyor\Types\ArrayType;
@@ -30,6 +31,9 @@ use Throwable;
 class Models extends Collector
 {
     protected Collection $modelComponents;
+
+    /** @var array<class-string<Model>, true> */
+    protected array $ignoredModels = [];
 
     public function __construct(protected Analyzer $analyzer)
     {
@@ -71,6 +75,12 @@ class Models extends Collector
         $result = $this->analyzer->analyzeClass($model)->result();
 
         if ($result === null) {
+            return;
+        }
+
+        if ($result->isIgnored() || Ignores::markedClass($model)) {
+            $this->ignoredModels[$model] = true;
+
             return;
         }
 
@@ -189,6 +199,12 @@ class Models extends Collector
 
         if (! $this->modelComponents->offsetExists($relatedModel->value)) {
             $this->toComponent($relatedModel->value);
+        }
+
+        // The related model is not being generated, so there is no type left
+        // for the relation to point at.
+        if (isset($this->ignoredModels[$relatedModel->value])) {
+            return null;
         }
 
         $collectionRelations = [

--- a/src/Collectors/Routes.php
+++ b/src/Collectors/Routes.php
@@ -11,6 +11,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Ranger\Components\Route;
 use Laravel\Ranger\Support\Config;
+use Laravel\Ranger\Support\Ignores;
 use ReflectionClass;
 use ReflectionProperty;
 use Spatie\StructureDiscoverer\Discover;
@@ -81,7 +82,30 @@ class Routes extends Collector
             return false;
         }
 
+        if ($this->actionIsMarkedIgnored($route)) {
+            return false;
+        }
+
         return count($this->ignoreUrls) === 0 || ! Str::is($this->ignoreUrls, $route->uri());
+    }
+
+    protected function actionIsMarkedIgnored(BaseRoute $route): bool
+    {
+        $controller = $route->getControllerClass();
+
+        if (! $controller || ! class_exists(ltrim($controller, '\\'))) {
+            return false;
+        }
+
+        $reflection = new ReflectionClass(ltrim($controller, '\\'));
+
+        if (Ignores::marked($reflection)) {
+            return true;
+        }
+
+        $method = $route->getActionMethod();
+
+        return $reflection->hasMethod($method) && Ignores::marked($reflection->getMethod($method));
     }
 
     protected function resolveResponses(Route $route): Route

--- a/src/RangerServiceProvider.php
+++ b/src/RangerServiceProvider.php
@@ -8,6 +8,8 @@ use Laravel\Ranger\Collectors\BroadcastEvents;
 use Laravel\Ranger\Collectors\Enums;
 use Laravel\Ranger\Collectors\Models;
 use Laravel\Ranger\Collectors\Routes;
+use Laravel\Ranger\Support\Ignores;
+use Laravel\Surveyor\Support\Markers;
 
 class RangerServiceProvider extends ServiceProvider
 {
@@ -29,6 +31,8 @@ class RangerServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerPublishing();
+
+        Markers::registerConditionResolver([Ignores::class, 'evaluate']);
     }
 
     /**

--- a/src/Support/Ignores.php
+++ b/src/Support/Ignores.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laravel\Ranger\Support;
+
+use Laravel\Surveyor\Analyzed\IgnoreMarker;
+use Laravel\Surveyor\Support\Markers;
+use ReflectionClass;
+use ReflectionClassConstant;
+use ReflectionEnum;
+use ReflectionEnumBackedCase;
+use ReflectionEnumUnitCase;
+use ReflectionMethod;
+use ReflectionProperty;
+use Throwable;
+
+class Ignores
+{
+    /**
+     * Whether a declaration should be left out right now. Used for the things
+     * found by reflection rather than by reading the file, such as a route's
+     * controller method or an enum case.
+     */
+    public static function marked(
+        ReflectionClass|ReflectionClassConstant|ReflectionEnum|ReflectionEnumBackedCase|ReflectionEnumUnitCase|ReflectionMethod|ReflectionProperty $reflection,
+    ): bool {
+        return static::marker($reflection)?->hides() ?? false;
+    }
+
+    public static function marker(
+        ReflectionClass|ReflectionClassConstant|ReflectionEnum|ReflectionEnumBackedCase|ReflectionEnumUnitCase|ReflectionMethod|ReflectionProperty $reflection,
+    ): ?IgnoreMarker {
+        return Markers::fromReflection($reflection);
+    }
+
+    /**
+     * @param  class-string|string  $class
+     */
+    public static function markedClass(string $class): bool
+    {
+        return class_exists($class) && static::marked(new ReflectionClass($class));
+    }
+
+    /**
+     * Resolve a marker condition: a config key or a [class, method] callable.
+     * Anything else keeps the declaration hidden.
+     */
+    public static function evaluate(string|array $condition): bool
+    {
+        if (is_string($condition)) {
+            return (bool) config($condition, false);
+        }
+
+        if (count($condition) !== 2) {
+            return false;
+        }
+
+        [$class, $method] = $condition;
+
+        if (! is_string($class) || ! is_string($method) || ! method_exists($class, $method)) {
+            return false;
+        }
+
+        try {
+            return (bool) app()->call([$class, $method]);
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/tests/Feature/BroadcastEventsTest.php
+++ b/tests/Feature/BroadcastEventsTest.php
@@ -16,7 +16,7 @@ describe('broadcast event collection', function () {
         $events = $this->collector->collect();
 
         expect($events)->not->toBeEmpty();
-        expect($events)->toHaveCount(4);
+        expect($events)->toHaveCount(5);
     });
 
     it('finds UserCreated event', function () {

--- a/tests/Feature/EnumsTest.php
+++ b/tests/Feature/EnumsTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 it('collects all enums from the application', function () {
     $enums = $this->collector->collect();
 
-    expect($enums)->toHaveCount(4);
+    expect($enums)->toHaveCount(6);
     expect($enums->pluck('name')->toArray())->toContain(Status::class, UserRole::class);
 });
 

--- a/tests/Feature/IgnoredTest.php
+++ b/tests/Feature/IgnoredTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Enums\ConditionalEnum;
+use App\Enums\IgnoredEnum;
+use App\Enums\PartiallyIgnoredEnum;
+use App\Events\IgnoredEvent;
+use App\Events\MarkedBroadcastWithEvent;
+use App\Http\Controllers\IgnoredController;
+use App\Http\Controllers\PartiallyIgnoredController;
+use App\Models\Post;
+use App\Models\SecretModel;
+use App\Models\Vault;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Laravel\Ranger\Collectors\BroadcastEvents;
+use Laravel\Ranger\Collectors\Enums;
+use Laravel\Ranger\Collectors\InertiaSharedData;
+use Laravel\Ranger\Collectors\Models;
+use Laravel\Ranger\Collectors\Routes;
+use Laravel\Ranger\Components\Enum;
+use Laravel\Ranger\Components\Model;
+use Laravel\Ranger\Components\Route;
+
+describe('routes', function () {
+    it('drops routes handled by a marked controller', function () {
+        RouteFacade::get('ignored-controller', [IgnoredController::class, 'index'])->name('ignored.index');
+
+        $routes = app(Routes::class)->collect();
+
+        expect($routes->first(fn (Route $route) => $route->name() === 'ignored.index'))->toBeNull();
+    });
+
+    it('drops routes handled by a marked method but keeps its siblings', function () {
+        RouteFacade::get('partially-ignored/keep', [PartiallyIgnoredController::class, 'keep'])->name('partial.keep');
+        RouteFacade::get('partially-ignored/hidden', [PartiallyIgnoredController::class, 'hidden'])->name('partial.hidden');
+
+        $routes = app(Routes::class)->collect();
+
+        expect($routes->first(fn (Route $route) => $route->name() === 'partial.keep'))->not->toBeNull();
+        expect($routes->first(fn (Route $route) => $route->name() === 'partial.hidden'))->toBeNull();
+    });
+});
+
+describe('enums', function () {
+    it('drops a marked enum', function () {
+        $enums = app(Enums::class)->collect();
+
+        expect($enums->first(fn (Enum $enum) => $enum->name === IgnoredEnum::class))->toBeNull();
+    });
+
+    it('drops a marked case and keeps the position of the rest', function () {
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === PartiallyIgnoredEnum::class);
+
+        expect($enum->cases)->toBe([
+            'PUBLIC_CASE' => 'public',
+            'OTHER_CASE' => 'other',
+        ]);
+    });
+});
+
+describe('models', function () {
+    it('carries a marker from an accessor defined in a trait', function () {
+        $post = app(Models::class)->collect()
+            ->first(fn (Model $model) => $model->name === Post::class);
+
+        expect(array_keys($post->getAttributes()))->toContain('public_note');
+        expect(array_keys($post->getAttributes()))->not->toContain('secret_note');
+    });
+
+    it('drops a marked model', function () {
+        $models = app(Models::class)->collect();
+
+        expect($models->first(fn (Model $model) => $model->name === SecretModel::class))->toBeNull();
+    });
+
+    it('drops a relation pointing at a marked model', function () {
+        $vault = app(Models::class)->collect()
+            ->first(fn (Model $model) => $model->name === Vault::class);
+
+        expect($vault)->not->toBeNull();
+        expect($vault->getRelations())->toBe([]);
+    });
+});
+
+describe('reading a member by name', function () {
+    it('falls back when the method a collector reads is marked', function () {
+        $event = app(BroadcastEvents::class)->collect()
+            ->first(fn ($event) => $event->className === MarkedBroadcastWithEvent::class);
+
+        expect($event)->not->toBeNull();
+        expect(array_keys($event->data->value))->toBe(['keptProperty']);
+    });
+
+    it('shares nothing when a marked share method is all there is', function () {
+        $shared = app(InertiaSharedData::class)->collect();
+
+        expect($shared)->toHaveCount(3);
+        expect($shared->filter(fn ($data) => $data->data->value === [])->count())
+            ->toBeGreaterThan(0);
+    });
+});
+
+describe('broadcast events', function () {
+    it('drops a marked event', function () {
+        $events = app(BroadcastEvents::class)->collect();
+
+        expect($events->pluck('name')->all())->not->toContain(IgnoredEvent::class);
+    });
+});
+
+describe('conditional markers', function () {
+    it('keeps a case while its config key is on', function () {
+        config(['features.fake' => true]);
+
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->toContain('FAKE');
+    });
+
+    it('drops a case when its config key is off', function () {
+        config(['features.fake' => false]);
+
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->not->toContain('FAKE');
+    });
+
+    it('drops a case when its config key is missing', function () {
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->toBe(['REAL', 'RETIRED']);
+    });
+
+    it('drops a case while its when condition passes', function () {
+        config(['features.hide_retired' => true]);
+
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->not->toContain('RETIRED');
+    });
+
+    it('keeps a case while its when condition fails', function () {
+        config(['features.hide_retired' => false]);
+
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->toContain('RETIRED');
+    });
+
+    it('keeps a case whose when condition key is missing', function () {
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->toContain('RETIRED');
+    });
+
+    it('keeps a case while its callable condition passes', function () {
+        config(['features.fake_callable' => true]);
+
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->toContain('CALLABLE_FAKE');
+    });
+
+    it('drops a case when its callable condition fails', function () {
+        config(['features.fake_callable' => false]);
+
+        $enum = app(Enums::class)->collect()
+            ->first(fn (Enum $enum) => $enum->name === ConditionalEnum::class);
+
+        expect(array_keys($enum->cases))->not->toContain('CALLABLE_FAKE');
+    });
+});

--- a/tests/Feature/InertiaSharedDataTest.php
+++ b/tests/Feature/InertiaSharedDataTest.php
@@ -10,7 +10,7 @@ beforeEach(function () {
 it('collects all inertia middleware classes', function () {
     $sharedData = $this->collector->collect();
 
-    expect($sharedData)->toHaveCount(2);
+    expect($sharedData)->toHaveCount(3);
 });
 
 it('creates shared data components with correct structure', function () {

--- a/tests/Feature/RangerTest.php
+++ b/tests/Feature/RangerTest.php
@@ -123,7 +123,7 @@ describe('enum callbacks', function () {
 
         $this->ranger->walk();
 
-        expect($enums)->toHaveCount(4);
+        expect($enums)->toHaveCount(6);
     });
 
     it('registers onEnums collection callback', function () {
@@ -136,7 +136,7 @@ describe('enum callbacks', function () {
         $this->ranger->walk();
 
         expect($receivedCollection)->toBeInstanceOf(Collection::class);
-        expect($receivedCollection)->toHaveCount(4);
+        expect($receivedCollection)->toHaveCount(6);
     });
 });
 
@@ -212,7 +212,7 @@ describe('multiple callbacks', function () {
 
         $this->ranger->walk();
 
-        expect($callCount)->toBe(8);
+        expect($callCount)->toBe(12);
     });
 
     it('supports callbacks for different types', function () {

--- a/workbench/app/Attributes/ConditionalIgnore.php
+++ b/workbench/app/Attributes/ConditionalIgnore.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Attributes;
+
+use Attribute;
+use Laravel\Surveyor\Contracts\ConditionallyIgnored;
+
+#[Attribute(Attribute::TARGET_ALL)]
+class ConditionalIgnore implements ConditionallyIgnored
+{
+    public function __construct(
+        public readonly string|array|null $unless = null,
+        public readonly string|array|null $when = null,
+    ) {
+        //
+    }
+
+    public function unless(): string|array|null
+    {
+        return $this->unless;
+    }
+
+    public function when(): string|array|null
+    {
+        return $this->when;
+    }
+}

--- a/workbench/app/Attributes/Ignore.php
+++ b/workbench/app/Attributes/Ignore.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Attributes;
+
+use Attribute;
+use Laravel\Surveyor\Contracts\Ignored;
+
+#[Attribute(Attribute::TARGET_ALL)]
+class Ignore implements Ignored
+{
+    //
+}

--- a/workbench/app/Enums/ConditionalEnum.php
+++ b/workbench/app/Enums/ConditionalEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Enums;
+
+use App\Attributes\ConditionalIgnore;
+use App\Support\FeatureFlags;
+
+enum ConditionalEnum: string
+{
+    case REAL = 'real';
+
+    #[ConditionalIgnore(unless: 'features.fake')]
+    case FAKE = 'fake';
+
+    #[ConditionalIgnore(unless: [FeatureFlags::class, 'fakeEnabled'])]
+    case CALLABLE_FAKE = 'callable-fake';
+
+    #[ConditionalIgnore(when: 'features.hide_retired')]
+    case RETIRED = 'retired';
+}

--- a/workbench/app/Enums/IgnoredEnum.php
+++ b/workbench/app/Enums/IgnoredEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+use App\Attributes\Ignore;
+
+#[Ignore]
+enum IgnoredEnum: string
+{
+    case ONE = 'one';
+    case TWO = 'two';
+}

--- a/workbench/app/Enums/PartiallyIgnoredEnum.php
+++ b/workbench/app/Enums/PartiallyIgnoredEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+use App\Attributes\Ignore;
+
+enum PartiallyIgnoredEnum: string
+{
+    case PUBLIC_CASE = 'public';
+
+    #[Ignore]
+    case INTERNAL_CASE = 'internal';
+
+    case OTHER_CASE = 'other';
+}

--- a/workbench/app/Events/IgnoredEvent.php
+++ b/workbench/app/Events/IgnoredEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events;
+
+use App\Attributes\Ignore;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+#[Ignore]
+class IgnoredEvent implements ShouldBroadcast
+{
+    public string $secret = 'value';
+
+    public function broadcastOn(): array
+    {
+        return [];
+    }
+}

--- a/workbench/app/Events/MarkedBroadcastWithEvent.php
+++ b/workbench/app/Events/MarkedBroadcastWithEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Events;
+
+use App\Attributes\Ignore;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class MarkedBroadcastWithEvent implements ShouldBroadcast
+{
+    public string $keptProperty = 'value';
+
+    #[Ignore]
+    public function broadcastWith(): array
+    {
+        return [
+            'secret' => 'value',
+        ];
+    }
+
+    public function broadcastOn(): array
+    {
+        return [];
+    }
+}

--- a/workbench/app/Http/Controllers/IgnoredController.php
+++ b/workbench/app/Http/Controllers/IgnoredController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Attributes\Ignore;
+
+#[Ignore]
+class IgnoredController
+{
+    public function index(): array
+    {
+        return ['secret' => 'value'];
+    }
+}

--- a/workbench/app/Http/Controllers/PartiallyIgnoredController.php
+++ b/workbench/app/Http/Controllers/PartiallyIgnoredController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Attributes\Ignore;
+
+class PartiallyIgnoredController
+{
+    public function keep(): array
+    {
+        return ['keep' => 'value'];
+    }
+
+    #[Ignore]
+    public function hidden(): array
+    {
+        return ['secret' => 'value'];
+    }
+}

--- a/workbench/app/Http/Middleware/HandleInertiaRequestsWithMarkedShare.php
+++ b/workbench/app/Http/Middleware/HandleInertiaRequestsWithMarkedShare.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Attributes\Ignore;
+use Inertia\Middleware;
+
+class HandleInertiaRequestsWithMarkedShare extends Middleware
+{
+    #[Ignore]
+    public function share($request): array
+    {
+        return [
+            'secret' => 'value',
+        ];
+    }
+}

--- a/workbench/app/Models/Concerns/HasNotes.php
+++ b/workbench/app/Models/Concerns/HasNotes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Attributes\Ignore;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+trait HasNotes
+{
+    public function publicNote(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'public');
+    }
+
+    #[Ignore]
+    public function secretNote(): Attribute
+    {
+        return Attribute::make(get: fn (): string => 'secret');
+    }
+}

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasNotes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Post extends Model
 {
-    use HasFactory;
+    use HasFactory, HasNotes;
 
     protected $fillable = [
         'title',

--- a/workbench/app/Models/SecretModel.php
+++ b/workbench/app/Models/SecretModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use App\Attributes\Ignore;
+use Illuminate\Database\Eloquent\Model;
+
+#[Ignore]
+class SecretModel extends Model
+{
+    //
+}

--- a/workbench/app/Models/Vault.php
+++ b/workbench/app/Models/Vault.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Vault extends Model
+{
+    public function secrets(): HasMany
+    {
+        return $this->hasMany(SecretModel::class);
+    }
+}

--- a/workbench/app/Support/FeatureFlags.php
+++ b/workbench/app/Support/FeatureFlags.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Support;
+
+class FeatureFlags
+{
+    public static function fakeEnabled(): bool
+    {
+        return (bool) config('features.fake_callable');
+    }
+}


### PR DESCRIPTION
Every collector now skips what an application has marked to be left out, so a consumer cannot publish something the author held back. This covers models, enums and their cases, broadcast events and channels, and controller classes and actions, whose routes drop along with them. A relation pointing at a dropped model goes too, since no type is left for it to point at.

Markers can carry a condition, resolved here as a config key or a [class, method] callable. Conditions are answered while collecting rather than while analyzing, so a cached analysis still gives each environment its own answer.