### PR TITLE
Handle enum meta and ignoring enum meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ranger->walk();
 | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | **Routes**                | All registered routes with URIs, parameters, HTTP verbs, controllers, validation rules, and possible responses |
 | **Models**                | Eloquent models with their attributes, types, and relationships                                                |
-| **Enums**                 | PHP backed enums with their cases and values                                                                   |
+| **Enums**                 | PHP enums with their cases, values, and the meta each case's methods return                                    |
 | **Broadcast Events**      | Events implementing `ShouldBroadcast` with their payloads                                                      |
 | **Broadcast Channels**    | Registered broadcast channels                                                                                  |
 | **Environment Variables** | Variables defined in your `.env` file                                                                          |
@@ -72,9 +72,33 @@ $ranger->walk();
 
 Each collector skips whatever carries an ignore marker. See [Ignore Markers](#ignore-markers).
 
+### Enum Meta
+
+An enum component carries its cases, and can also hand back what every no-argument method on the enum returns for each case, keyed by case name then method name:
+
+```php
+enum Status: string
+{
+    case Active = 'active';
+    case Draft = 'draft';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Active => 'Is Active',
+            self::Draft => 'Is Draft',
+        };
+    }
+}
+
+$enum->meta(); // ['Active' => ['label' => 'Is Active'], 'Draft' => ['label' => 'Is Draft']]
+```
+
+Resolving means calling the methods, so it waits until you ask: collecting an enum never runs an application's own code. A method is left out unless it is public, declared on the enum itself, takes no required arguments, and returns something representable as data. Objects are unwrapped through `JsonSerializable`, `Arrayable`, or `Stringable`, and a backed enum comes back as its value. A method that throws, or returns something we cannot represent, is left out for that case alone, so a method covering only some cases still makes it through.
+
 ### Ignore Markers
 
-Every collector leaves out declarations an application has marked to be left out, so a consumer cannot pass on something the author held back. Ranger honors any attribute implementing `Laravel\Surveyor\Contracts\Ignored`, on a model, an enum or one of its cases, a broadcast event or channel, and a controller class or action, whose routes are dropped with it. A relation pointing at a marked model is dropped too, since no type is left to point at.
+Every collector leaves out declarations an application has marked to be left out, so a consumer cannot pass on something the author held back. Ranger honors any attribute implementing `Laravel\Surveyor\Contracts\Ignored`, on a model, an enum or one of its cases or methods, a broadcast event or channel, and a controller class or action, whose routes are dropped with it. A relation pointing at a marked model is dropped too, since no type is left to point at.
 
 Markers can carry a condition, which ranger resolves as a config key, a `[class, method]` callable, or a plain bool:
 

--- a/src/Components/Enum.php
+++ b/src/Components/Enum.php
@@ -3,10 +3,14 @@
 namespace Laravel\Ranger\Components;
 
 use Laravel\Ranger\Concerns\HasFilePath;
+use Laravel\Ranger\Support\EnumMeta;
 
 class Enum
 {
     use HasFilePath;
+
+    /** @var array<string, array<string, mixed>>|null */
+    protected ?array $meta = null;
 
     /**
      * @param  array<string, int|string|null>  $cases
@@ -16,5 +20,20 @@ class Enum
         public readonly array $cases
     ) {
         //
+    }
+
+    /**
+     * The value every no-argument method returns for every case, keyed by case
+     * name then method name.
+     *
+     * Resolving means calling the methods, so it is left until a consumer asks
+     * rather than done while collecting: an application that has no use for the
+     * values never has its code run.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function meta(): array
+    {
+        return $this->meta ??= EnumMeta::resolve($this->name, array_keys($this->cases));
     }
 }

--- a/src/Support/EnumMeta.php
+++ b/src/Support/EnumMeta.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Laravel\Ranger\Support;
+
+use BackedEnum;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+use ReflectionEnum;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Stringable;
+use Throwable;
+use UnitEnum;
+
+class EnumMeta
+{
+    protected const MAX_DEPTH = 10;
+
+    /**
+     * Resolve the value of every no-argument method for every case.
+     *
+     * The returned array is keyed by case name, then by method name. A method
+     * that throws or returns something we cannot represent is left out for that
+     * case alone, so methods that only cover some of the cases still make it
+     * through.
+     *
+     * @param  class-string<UnitEnum>  $enum
+     * @param  list<string>  $cases  Names of the cases to resolve; the rest are left alone.
+     * @return array<string, array<string, mixed>>
+     */
+    public static function resolve(string $enum, array $cases): array
+    {
+        $methods = self::eligibleMethods($enum);
+
+        if ($methods === [] || $cases === []) {
+            return [];
+        }
+
+        $resolved = [];
+
+        foreach ($enum::cases() as $case) {
+            if (! in_array($case->name, $cases, true)) {
+                continue;
+            }
+
+            foreach ($methods as $method) {
+                try {
+                    $value = self::normalize($case->{$method}());
+                } catch (Throwable) {
+                    continue;
+                }
+
+                $resolved[$case->name][$method] = $value;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  class-string<UnitEnum>  $enum
+     * @return list<string>
+     */
+    protected static function eligibleMethods(string $enum): array
+    {
+        $reflection = new ReflectionEnum($enum);
+
+        return collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))
+            ->reject(fn (ReflectionMethod $method) => $method->isStatic()
+                || $method->getDeclaringClass()->getName() !== $reflection->getName()
+                || str_starts_with($method->getName(), '__')
+                || $method->getNumberOfRequiredParameters() > 0
+                || $method->isGenerator()
+                || self::returnsNothing($method)
+                || Ignores::marked($method))
+            ->map(fn (ReflectionMethod $method) => $method->getName())
+            ->values()
+            ->all();
+    }
+
+    protected static function returnsNothing(ReflectionMethod $method): bool
+    {
+        $type = $method->getReturnType();
+
+        return $type instanceof ReflectionNamedType
+            && in_array(strtolower($type->getName()), ['void', 'never'], true);
+    }
+
+    protected static function normalize(mixed $value, int $depth = 0): mixed
+    {
+        if ($depth > self::MAX_DEPTH) {
+            throw new UnsupportedEnumMetaValue;
+        }
+
+        if ($value === null || is_bool($value) || is_int($value) || is_string($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            if (! is_finite($value)) {
+                throw new UnsupportedEnumMetaValue;
+            }
+
+            return $value;
+        }
+
+        if (is_array($value)) {
+            return array_map(fn ($item) => self::normalize($item, $depth + 1), $value);
+        }
+
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+
+        if ($value instanceof JsonSerializable) {
+            return self::normalize($value->jsonSerialize(), $depth + 1);
+        }
+
+        if ($value instanceof Arrayable) {
+            return self::normalize($value->toArray(), $depth + 1);
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        throw new UnsupportedEnumMetaValue;
+    }
+}

--- a/src/Support/UnsupportedEnumMetaValue.php
+++ b/src/Support/UnsupportedEnumMetaValue.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Ranger\Support;
+
+use RuntimeException;
+
+class UnsupportedEnumMetaValue extends RuntimeException
+{
+    //
+}

--- a/tests/Feature/EnumMetaTest.php
+++ b/tests/Feature/EnumMetaTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Enums\MetaEnum;
+use App\Enums\PartiallyIgnoredEnum;
+use App\Enums\Status;
+use App\Support\MetaCalls;
+use Illuminate\Support\Facades\Config;
+use Laravel\Ranger\Collectors\Enums;
+use Laravel\Ranger\Components\Enum;
+
+beforeEach(function () {
+    MetaCalls::flush();
+
+    $this->meta = fn (string $enum) => app(Enums::class)->collect()
+        ->first(fn (Enum $component) => $component->name === $enum)
+        ->meta();
+});
+
+it('resolves a method for every case', function () {
+    expect(($this->meta)(MetaEnum::class))->toHaveKeys(['FIRST', 'SECOND']);
+
+    expect(($this->meta)(MetaEnum::class)['FIRST']['label'])->toBe('The First');
+    expect(($this->meta)(MetaEnum::class)['SECOND']['label'])->toBe('The Second');
+    expect(($this->meta)(MetaEnum::class)['FIRST']['color'])->toBe('green');
+});
+
+it('normalizes values it can represent', function () {
+    $meta = ($this->meta)(MetaEnum::class)['FIRST'];
+
+    expect($meta['next'])->toBe('second');
+    expect($meta['summary'])->toBe(['total' => 100, 'currency' => 'usd']);
+    expect($meta['tags'])->toBe(['one', ['nested' => true]]);
+});
+
+it('leaves out a method that throws for one case alone', function () {
+    $meta = ($this->meta)(MetaEnum::class);
+
+    expect($meta['FIRST']['onlyForFirst'])->toBe('first only');
+    expect($meta['SECOND'])->not->toHaveKey('onlyForFirst');
+});
+
+it('leaves out a value it cannot represent', function () {
+    expect(($this->meta)(MetaEnum::class)['FIRST'])->not->toHaveKey('unrepresentable');
+});
+
+it('leaves out methods it cannot call for every case', function () {
+    expect(($this->meta)(MetaEnum::class)['FIRST'])
+        ->not->toHaveKey('withArgument')
+        ->not->toHaveKey('generated')
+        ->not->toHaveKey('nothing')
+        ->not->toHaveKey('statically');
+});
+
+it('leaves out a marked method', function () {
+    expect(($this->meta)(MetaEnum::class)['FIRST'])->not->toHaveKey('internalNote');
+});
+
+it('leaves out a conditionally marked method while its condition fails', function () {
+    expect(($this->meta)(MetaEnum::class)['FIRST'])->not->toHaveKey('flagged');
+});
+
+it('keeps a conditionally marked method while its condition holds', function () {
+    Config::set('features.fake', true);
+
+    expect(($this->meta)(MetaEnum::class)['FIRST']['flagged'])->toBe('flagged');
+});
+
+it('is empty for an enum without methods', function () {
+    expect(($this->meta)(Status::class))->toBe([]);
+});
+
+it('never calls a method on a marked case', function () {
+    $meta = ($this->meta)(PartiallyIgnoredEnum::class);
+
+    expect(array_keys($meta))->toBe(['PUBLIC_CASE', 'OTHER_CASE']);
+    expect(MetaCalls::$cases)->toBe(['PUBLIC_CASE', 'OTHER_CASE']);
+});
+
+it('resolves once per component', function () {
+    $component = app(Enums::class)->collect()
+        ->first(fn (Enum $enum) => $enum->name === PartiallyIgnoredEnum::class);
+
+    $component->meta();
+    $component->meta();
+
+    expect(MetaCalls::$cases)->toBe(['PUBLIC_CASE', 'OTHER_CASE']);
+});
+
+it('does not resolve while collecting', function () {
+    app(Enums::class)->collect();
+
+    expect(MetaCalls::$cases)->toBe([]);
+});

--- a/tests/Feature/EnumsTest.php
+++ b/tests/Feature/EnumsTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 it('collects all enums from the application', function () {
     $enums = $this->collector->collect();
 
-    expect($enums)->toHaveCount(6);
+    expect($enums)->toHaveCount(7);
     expect($enums->pluck('name')->toArray())->toContain(Status::class, UserRole::class);
 });
 

--- a/tests/Feature/RangerTest.php
+++ b/tests/Feature/RangerTest.php
@@ -123,7 +123,7 @@ describe('enum callbacks', function () {
 
         $this->ranger->walk();
 
-        expect($enums)->toHaveCount(6);
+        expect($enums)->toHaveCount(7);
     });
 
     it('registers onEnums collection callback', function () {
@@ -136,7 +136,7 @@ describe('enum callbacks', function () {
         $this->ranger->walk();
 
         expect($receivedCollection)->toBeInstanceOf(Collection::class);
-        expect($receivedCollection)->toHaveCount(6);
+        expect($receivedCollection)->toHaveCount(7);
     });
 });
 
@@ -212,7 +212,7 @@ describe('multiple callbacks', function () {
 
         $this->ranger->walk();
 
-        expect($callCount)->toBe(12);
+        expect($callCount)->toBe(14);
     });
 
     it('supports callbacks for different types', function () {

--- a/tests/Unit/InventoryTest.php
+++ b/tests/Unit/InventoryTest.php
@@ -45,7 +45,7 @@ it('does not follow ancestry beyond the scanned paths', function () {
 
 it('finds enums', function () {
     expect($this->inventory->enums())
-        ->toHaveCount(4)
+        ->toHaveCount(8)
         ->toContain(Status::class, UserRole::class);
 });
 

--- a/workbench/app/Enums/MetaEnum.php
+++ b/workbench/app/Enums/MetaEnum.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Enums;
+
+use App\Attributes\ConditionalIgnore;
+use App\Attributes\Ignore;
+use App\Support\CheckoutSummary;
+use Generator;
+use RuntimeException;
+
+enum MetaEnum: string
+{
+    case FIRST = 'first';
+    case SECOND = 'second';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::FIRST => 'The First',
+            self::SECOND => 'The Second',
+        };
+    }
+
+    public function color(): string
+    {
+        return 'green';
+    }
+
+    public function next(): self
+    {
+        return $this === self::FIRST ? self::SECOND : self::FIRST;
+    }
+
+    public function summary(): CheckoutSummary
+    {
+        return new CheckoutSummary(total: 100, currency: 'usd');
+    }
+
+    public function tags(): array
+    {
+        return ['one', ['nested' => true]];
+    }
+
+    public function onlyForFirst(): string
+    {
+        if ($this === self::SECOND) {
+            throw new RuntimeException('Not available.');
+        }
+
+        return 'first only';
+    }
+
+    public function unrepresentable(): object
+    {
+        return new class {};
+    }
+
+    #[Ignore]
+    public function internalNote(): string
+    {
+        return 'held back';
+    }
+
+    #[ConditionalIgnore(unless: 'features.fake')]
+    public function flagged(): string
+    {
+        return 'flagged';
+    }
+
+    public function withArgument(string $prefix): string
+    {
+        return $prefix.$this->value;
+    }
+
+    public function generated(): Generator
+    {
+        yield 'nope';
+    }
+
+    public function nothing(): void
+    {
+        //
+    }
+
+    public static function statically(): string
+    {
+        return 'static';
+    }
+}

--- a/workbench/app/Enums/PartiallyIgnoredEnum.php
+++ b/workbench/app/Enums/PartiallyIgnoredEnum.php
@@ -3,6 +3,7 @@
 namespace App\Enums;
 
 use App\Attributes\Ignore;
+use App\Support\MetaCalls;
 
 enum PartiallyIgnoredEnum: string
 {
@@ -12,4 +13,11 @@ enum PartiallyIgnoredEnum: string
     case INTERNAL_CASE = 'internal';
 
     case OTHER_CASE = 'other';
+
+    public function label(): string
+    {
+        MetaCalls::record($this->name);
+
+        return ucfirst($this->value);
+    }
 }

--- a/workbench/app/Support/MetaCalls.php
+++ b/workbench/app/Support/MetaCalls.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Support;
+
+class MetaCalls
+{
+    /** @var list<string> */
+    public static array $cases = [];
+
+    public static function record(string $case): void
+    {
+        static::$cases[] = $case;
+    }
+
+    public static function flush(): void
+    {
+        static::$cases = [];
+    }
+}


### PR DESCRIPTION
Originally, Wayfinder was evaluating enum meta (enum methods with no args). Moved the (lazy) evaluation up the chain to Ranger so that it can also ignore enum meta when specified.