### PR TITLE
Resolve middleware aliases when inferring URL defaults

### DIFF
--- a/src/Collectors/Routes.php
+++ b/src/Collectors/Routes.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ranger\Collectors;
 
 use Closure;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Routing\Route as BaseRoute;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
@@ -25,6 +26,8 @@ class Routes extends Collector
 
     protected $universalUrlDefaults = [];
 
+    protected $globalMiddleware = [];
+
     protected array $ignoreNames = [];
 
     protected array $ignoreUrls = [];
@@ -46,12 +49,41 @@ class Routes extends Collector
      */
     public function collect(): Collection
     {
+        $this->syncMiddlewareFromHttpKernel();
         $this->collectProviderUrlDefaults();
 
         return collect($this->router->getRoutes())
             ->filter($this->filterRoute(...))
             ->map($this->mapToRoute(...))
             ->map($this->resolveResponses(...));
+    }
+
+    protected function syncMiddlewareFromHttpKernel(): void
+    {
+        if (! app()->bound(HttpKernel::class)) {
+            return;
+        }
+
+        $groups = $this->router->getMiddlewareGroups();
+        $aliases = $this->router->getMiddleware();
+
+        // Resolving the kernel syncs its middleware onto the router, overwriting existing groups
+        $kernel = app(HttpKernel::class);
+
+        foreach ($groups as $group => $middleware) {
+            foreach ($middleware as $name) {
+                $this->router->pushMiddlewareToGroup($group, $name);
+            }
+        }
+
+        foreach ($aliases as $name => $class) {
+            $this->router->aliasMiddleware($name, $class);
+        }
+
+        // Global middleware is never synced to the router, and the getter is not on the kernel contract
+        if (method_exists($kernel, 'getGlobalMiddleware')) {
+            $this->globalMiddleware = $kernel->getGlobalMiddleware();
+        }
     }
 
     protected function collectProviderUrlDefaults(): void
@@ -63,6 +95,13 @@ class Routes extends Collector
                 $this->universalUrlDefaults,
                 $this->getDefaultsFromClassMethod($class, 'register'),
                 $this->getDefaultsFromClassMethod($class, 'boot'),
+            );
+        }
+
+        foreach ($this->globalMiddleware as $middleware) {
+            $this->universalUrlDefaults = array_merge(
+                $this->universalUrlDefaults,
+                $this->collectMiddlewareDefaults($middleware),
             );
         }
     }

--- a/tests/Feature/MiddlewareUrlDefaultsTest.php
+++ b/tests/Feature/MiddlewareUrlDefaultsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Http\Middleware\GlobalUrlDefaultsMiddleware;
+use App\Http\Middleware\UrlDefaultsMiddleware;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Laravel\Ranger\Collectors\Routes;
+use Laravel\Ranger\Components\Route;
+use Laravel\Ranger\Support\RouteParameter;
+
+// These tests register their middleware through afterResolving to mirror
+// withMiddleware(), which only reaches the kernel once it resolves. Nothing here
+// may resolve the kernel before the test body does, so this file deliberately
+// collects routes on demand rather than in a beforeEach.
+function localeParameter(string $uriFragment): RouteParameter
+{
+    return app(Routes::class)->collect()
+        ->first(fn (Route $route) => str_contains($route->uri(), $uriFragment))
+        ->parameters()
+        ->first(fn (RouteParameter $parameter) => $parameter->name === 'locale');
+}
+
+it('resolves URL defaults from an aliased middleware', function () {
+    $this->app->afterResolving(Kernel::class, fn ($kernel) => $kernel->setMiddlewareAliases([
+        'url-defaults' => UrlDefaultsMiddleware::class,
+    ]));
+
+    RouteFacade::middleware('url-defaults')->get('/alias-defaults/{locale}', fn () => '');
+
+    $locale = localeParameter('alias-defaults');
+
+    expect($locale->optional)->toBeTrue();
+    expect($locale->default)->toBe('en');
+});
+
+it('resolves URL defaults from a kernel middleware group', function () {
+    $this->app->afterResolving(Kernel::class, fn ($kernel) => $kernel->setMiddlewareGroups([
+        'tenant' => [UrlDefaultsMiddleware::class],
+    ]));
+
+    RouteFacade::middleware('tenant')->get('/kernel-group-defaults/{locale}', fn () => '');
+
+    $locale = localeParameter('kernel-group-defaults');
+
+    expect($locale->optional)->toBeTrue();
+    expect($locale->default)->toBe('en');
+});
+
+it('resolves URL defaults from global middleware', function () {
+    // Global middleware never reaches the router, so this only works if the defaults
+    // are read off the kernel itself.
+    $this->app->afterResolving(Kernel::class, fn ($kernel) => $kernel->setGlobalMiddleware([
+        UrlDefaultsMiddleware::class,
+    ]));
+
+    RouteFacade::get('/global-defaults/{locale}', fn () => '');
+
+    $locale = localeParameter('global-defaults');
+
+    expect($locale->optional)->toBeTrue();
+    expect($locale->default)->toBe('en');
+});
+
+it('drops URL defaults when the middleware is excluded by alias', function () {
+    // Excluded middleware runs through the same alias map, so without the kernel's aliases
+    // the exclusion is missed and the parameter is wrongly reported as optional.
+    $this->app->afterResolving(Kernel::class, fn ($kernel) => $kernel->setMiddlewareAliases([
+        'url-defaults' => UrlDefaultsMiddleware::class,
+    ]));
+
+    RouteFacade::middleware(UrlDefaultsMiddleware::class)
+        ->withoutMiddleware('url-defaults')
+        ->get('/excluded-defaults/{locale}', fn () => '');
+
+    expect(localeParameter('excluded-defaults')->optional)->toBeFalse();
+});
+
+it('prefers route middleware defaults over global middleware defaults', function () {
+    $this->app->afterResolving(Kernel::class, fn ($kernel) => $kernel->setGlobalMiddleware([
+        GlobalUrlDefaultsMiddleware::class,
+    ]));
+
+    RouteFacade::middleware(UrlDefaultsMiddleware::class)
+        ->get('/precedence-defaults/{locale}', fn () => '');
+
+    expect(localeParameter('precedence-defaults')->default)->toBe('en');
+});

--- a/workbench/app/Http/Middleware/GlobalUrlDefaultsMiddleware.php
+++ b/workbench/app/Http/Middleware/GlobalUrlDefaultsMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Support\Facades\URL;
+
+class GlobalUrlDefaultsMiddleware
+{
+    public function handle($request, $next)
+    {
+        URL::defaults([
+            'locale' => 'global',
+        ]);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Bringing https://github.com/laravel/wayfinder/pull/295 into `next`, which needs the fix here rather than in Wayfinder.
